### PR TITLE
Pin version of embedded-hal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords    = ["stepper", "motor", "driver", "abstract", "interface"]
 categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 [dependencies]
-embedded-hal  = "1.0.0-alpha.2"
+embedded-hal  = "=1.0.0-alpha.2"
 embedded-time = "0.10.0"
 paste         = "1.0.2"
 


### PR DESCRIPTION
Alpha versions might introduce breaking changes, but Cargo will pick
them up automatically, as if they were semver-compatible. To prevent
breakage, the version needs to be pinned.