### PR TITLE
Add a minimal driver implementation for the DRV8825

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members         = ["drivers/drv8825", "drivers/stspin220"]
-default-members = [".", "drivers/stspin220"]
+default-members = [".", "drivers/drv8825", "drivers/stspin220"]
 
 [package]
 name    = "step-dir"
@@ -21,4 +21,5 @@ paste         = "1.0.2"
 
 [features]
 default = ["stspin220"]
+drv8825 = []
 stspin220 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ embedded-time = "0.10.0"
 paste         = "1.0.2"
 
 [features]
-default = ["stspin220"]
+default = ["drv8825", "stspin220"]
 drv8825 = []
 stspin220 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members         = ["drivers/stspin220"]
+members         = ["drivers/drv8825", "drivers/stspin220"]
 default-members = [".", "drivers/stspin220"]
 
 [package]

--- a/drivers/drv8825/Cargo.toml
+++ b/drivers/drv8825/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "drv8825"
+version = "0.1.0"
+authors = [
+    "Hanno Braun <hanno@braun-embedded.com>",
+    "Jesse Braham <jesse@beta7.io>",
+]
+edition = "2018"
+
+description = "Driver crate for the DRV8825 stepper motor driver"
+repository  = "https://github.com/braun-embedded/step-dir"
+license     = "0BSD"
+keywords    = ["step-dir", "stepper", "motor", "driver", "pololu"]
+categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
+
+
+[dependencies.step-dir]
+version = "0.2.0"
+path    = "../.."

--- a/drivers/drv8825/README.md
+++ b/drivers/drv8825/README.md
@@ -1,0 +1,19 @@
+# DRV8825 Driver [![crates.io](https://img.shields.io/crates/v/drv8825.svg)](https://crates.io/crates/drv8825) [![Documentation](https://docs.rs/drv8825/badge.svg)](https://docs.rs/drv8825) ![CI Build](https://github.com/braun-embedded/step-dir/workflows/CI%20Build/badge.svg)
+
+## About
+
+Rust driver crate for the [DRV8825] stepper motor driver. Carrier boards for this chip are [available from Pololu](https://www.pololu.com/category/154/drv8825-stepper-motor-driver-carriers-high-current).
+
+## Status
+
+This driver is currently very basic in its capabilities. Its design is experimental, and more revisions to the API are expected.
+
+## License
+
+This project is open source software, licensed under the terms of the [Zero Clause BSD License] (0BSD, for short). This basically means you can do anything with the software, without any restrictions, but you can't hold the authors liable for problems.
+
+See [LICENSE.md] for full details.
+
+[drv8825]: https://www.ti.com/product/DRV8825
+[zero clause bsd license]: https://opensource.org/licenses/0BSD
+[license.md]: https://github.com/braun-embedded/step-dir/blob/master/LICENSE.md

--- a/drivers/drv8825/src/drv8825.rs
+++ b/drivers/drv8825/src/drv8825.rs
@@ -1,0 +1,369 @@
+//! DRV8825 Driver
+//!
+//! Platform-agnostic driver for the DRV8825 stepper motor driver. This module
+//! can be used on any platform for which implementations of the required
+//! [embedded-hal] traits are available.
+//!
+//! The entry point to this module is the [`DRV8825`] struct.
+//!
+//! # Example
+//!
+//! ``` rust
+//! # fn main()
+//! #     -> Result<
+//! #         (),
+//! #         step_dir::drv8825::StepError<core::convert::Infallible>
+//! #     > {
+//! #
+//! use step_dir::{
+//!     embedded_time::{duration::Microseconds, Clock as _},
+//!     drv8825::DRV8825,
+//!     Dir, Step as _,
+//! };
+//!
+//! const STEP_DELAY: Microseconds = Microseconds(500);
+//!
+//! # struct Pin;
+//! # impl step_dir::embedded_hal::digital::OutputPin for Pin {
+//! #     type Error = core::convert::Infallible;
+//! #     fn try_set_low(&mut self) -> Result<(), Self::Error> { Ok(()) }
+//! #     fn try_set_high(&mut self) -> Result<(), Self::Error> { Ok(()) }
+//! # }
+//! #
+//! # struct Clock(std::time::Instant);
+//! # impl step_dir::embedded_time::Clock for Clock {
+//! #     type T = u32;
+//! #     const SCALING_FACTOR: step_dir::embedded_time::fraction::Fraction =
+//! #         step_dir::embedded_time::fraction::Fraction::new(1, 1_000_000);
+//! #     fn try_now(&self)
+//! #         -> Result<
+//! #             step_dir::embedded_time::Instant<Self>,
+//! #             step_dir::embedded_time::clock::Error
+//! #         >
+//! #     {
+//! #         Ok(
+//! #             step_dir::embedded_time::Instant::new(
+//! #                 self.0.elapsed().as_micros() as u32
+//! #             )
+//! #         )
+//! #     }
+//! # }
+//! #
+//! # let step = Pin;
+//! # let dir = Pin;
+//! # let mut clock = Clock(std::time::Instant::now());
+//! #
+//! // You need to acquire the GPIO pins connected to the STEP and DIR signals.
+//! // How you do this depends on your target platform. All the driver cares
+//! // about is that they implement `embedded_hal::digital::OutputPin`. You also
+//! // need an implementation of `embedded_hal::blocking::DelayUs`.
+//!
+//! // Create driver API from STEP and DIR pins.
+//! let mut driver = DRV8825::from_step_dir_pins(step, dir);
+//!
+//! // Rotate stepper motor by a few steps.
+//! for _ in 0 .. 5 {
+//!     let timer = clock.new_timer(STEP_DELAY).start()?;
+//!     driver.step(Dir::Forward, &clock)?;
+//!     timer.wait()?;
+//! }
+//!
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [embedded-hal]: https://crates.io/crates/embedded-hal
+
+use step_dir::{
+    embedded_hal::digital::{OutputPin, PinState},
+    embedded_time::{duration::Nanoseconds, Clock, TimeError},
+    Dir as DirTrait, SetStepMode, Step as StepTrait, StepMode,
+};
+
+/// The DRV8825 driver API
+///
+/// You can create an instance of this struct by calling
+/// [`DRV8825::from_step_dir_pins`]. See [module documentation] for a full
+/// example that uses this API.
+///
+/// [module documentation]: index.html
+pub struct DRV8825<Enable, Fault, Sleep, Reset, Mode0, Mode1, Mode2, Step, Dir>
+{
+    enable: Enable,
+    fault: Fault,
+    sleep: Sleep,
+    reset: Reset,
+    mode0: Mode0,
+    mode1: Mode1,
+    mode2: Mode2,
+    step: Step,
+    dir: Dir,
+}
+
+impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
+    /// Create a new instance of `DRV8825`
+    ///
+    /// Creates an instance of this struct from just the STEP and DIR pins. It
+    /// expects the types that represent those pins to implement [`OutputPin`].
+    ///
+    /// The resulting instance can be used to step the motor using
+    /// [`DRV8825::step`]. All other capabilities of the DRV8825, like
+    /// the power-up sequence, selecting a step mode, or controlling the power
+    /// state, explicitly enabled, or managed externally.
+    ///
+    /// To enable additional capabilities, see
+    /// [`DRV8825::enable_mode_control`].
+    pub fn from_step_dir_pins<Error>(step: Step, dir: Dir) -> Self
+    where
+        Step: OutputPin<Error = Error>,
+        Dir: OutputPin<Error = Error>,
+    {
+        Self {
+            enable: (),
+            fault: (),
+            sleep: (),
+            reset: (),
+            mode0: (),
+            mode1: (),
+            mode2: (),
+            step,
+            dir,
+        }
+    }
+}
+
+impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
+    /// Enables support for step mode control and sets the initial step mode
+    ///
+    /// Consumes this instance of `DRV8825` and returns another instance that
+    /// has support for controlling the step mode. Requires the additional pins
+    /// for doing so, namely RESET, MODE0, MODE1, and MODE2. It expects the
+    /// types that represent those pins to implement [`OutputPin`].
+    ///
+    /// This method is only available when those pins have not been provided
+    /// yet. After this method has been called once, you can use
+    /// [`DRV8825::set_step_mode`] to change the step mode again.
+    pub fn enable_mode_control<
+        Reset,
+        Mode0,
+        Mode1,
+        Mode2,
+        Clk,
+        OutputPinError,
+    >(
+        self,
+        reset: Reset,
+        mode0: Mode0,
+        mode1: Mode1,
+        mode2: Mode2,
+        step_mode: StepMode,
+        clock: &Clk,
+    ) -> Result<
+        DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>,
+        ModeError<OutputPinError>,
+    >
+    where
+        Reset: OutputPin<Error = OutputPinError>,
+        Mode0: OutputPin<Error = OutputPinError>,
+        Mode1: OutputPin<Error = OutputPinError>,
+        Mode2: OutputPin<Error = OutputPinError>,
+        Clk: Clock,
+    {
+        let mut self_ = DRV8825 {
+            enable: self.enable,
+            fault: self.fault,
+            sleep: self.sleep,
+            reset,
+            mode0,
+            mode1,
+            mode2,
+            step: self.step,
+            dir: self.dir,
+        };
+
+        self_.set_step_mode(step_mode, clock)?;
+
+        Ok(self_)
+    }
+}
+
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> SetStepMode
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
+where
+    Reset: OutputPin<Error = OutputPinError>,
+    Mode0: OutputPin<Error = OutputPinError>,
+    Mode1: OutputPin<Error = OutputPinError>,
+    Mode2: OutputPin<Error = OutputPinError>,
+{
+    type Error = ModeError<OutputPinError>;
+
+    /// Sets the step mode
+    ///
+    /// This method is only available, if all the pins required for setting the
+    /// step mode have been provided using [`DRV8825::enable_mode_control`].
+    fn set_step_mode<Clk: Clock>(
+        &mut self,
+        step_mode: StepMode,
+        clock: &Clk,
+    ) -> Result<(), Self::Error> {
+        // 7.6 Timing Requirements (page 7)
+        // https://www.ti.com/lit/ds/symlink/drv8825.pdf
+        const SETUP_TIME: Nanoseconds = Nanoseconds(650);
+
+        // Reset the device's internal logic and disable the h-bridge drivers.
+        self.reset
+            .try_set_low()
+            .map_err(|err| ModeError::OutputPin(err))?;
+
+        // Set mode signals. All this repetition is messy. I decided not to do
+        // anything about it and wait for the next embedded-hal alpha version,
+        // which has features that would help here.
+        let (mode0, mode1, mode2) = step_mode_to_signals(&step_mode);
+        self.mode0
+            .try_set_state(mode0)
+            .map_err(|err| ModeError::OutputPin(err))?;
+        self.mode1
+            .try_set_state(mode1)
+            .map_err(|err| ModeError::OutputPin(err))?;
+        self.mode2
+            .try_set_state(mode2)
+            .map_err(|err| ModeError::OutputPin(err))?;
+
+        // Need to wait for the MODEx input setup time.
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
+
+        // Re-enable the h-bridge drivers using the new configuration.
+        self.reset
+            .try_set_high()
+            .map_err(|err| ModeError::OutputPin(err))?;
+
+        // Now the mode pins need to stay as they are for the MODEx input hold
+        // time, for the settings to take effect.
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
+
+        Ok(())
+    }
+}
+
+impl<Step, Dir, OutputPinError> StepTrait
+    for DRV8825<(), (), (), (), (), (), (), Step, Dir>
+where
+    Step: OutputPin<Error = OutputPinError>,
+    Dir: OutputPin<Error = OutputPinError>,
+{
+    type Error = StepError<OutputPinError>;
+
+    /// Rotates the motor one (micro-)step in the given direction
+    ///
+    /// Sets the DIR pin according to the `dir` argument, initiates a step pulse
+    /// by setting STEP HIGH, then ends the step pulse by setting STEP LOW
+    /// again. The method blocks while this is going on.
+    ///
+    /// This should result in the motor making one step. To achieve a specific
+    /// speed, the user must call this method at the appropriate frequency.
+    ///
+    /// Requires a reference to an `embedded_time::Clock` implementation to
+    /// handle the timing. Please make sure that the timer doesn't overflow
+    /// while this method is running.
+    ///
+    /// Any errors that occur are wrapped in a [`StepError`] and returned to the
+    /// user directly. This might leave the driver API in an invalid state, for
+    /// example if STEP has been set HIGH, but an error occurs before it can be
+    /// set LOW again.
+    fn step<Clk: Clock>(
+        &mut self,
+        dir: DirTrait,
+        clock: &Clk,
+    ) -> Result<(), Self::Error> {
+        // 7.6 Timing Requirements (page 7)
+        // https://www.ti.com/lit/ds/symlink/drv8825.pdf
+        const SETUP_TIME: Nanoseconds = Nanoseconds(650);
+        const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
+
+        match dir {
+            DirTrait::Forward => self
+                .dir
+                .try_set_high()
+                .map_err(|err| StepError::OutputPin(err))?,
+            DirTrait::Backward => self
+                .dir
+                .try_set_low()
+                .map_err(|err| StepError::OutputPin(err))?,
+        }
+
+        // According to the datasheet, we need to wait at least 650ns between
+        // setting DIR and starting the STEP pulse
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
+
+        // Start step pulse
+        self.step
+            .try_set_high()
+            .map_err(|err| StepError::OutputPin(err))?;
+
+        // There are two delays we need to adhere to:
+        // - The minimum DIR hold time of 650ns
+        // - The minimum STEP high time of 1.9us
+        clock.new_timer(PULSE_LENGTH).start()?.wait()?;
+
+        // End step pulse
+        self.step
+            .try_set_low()
+            .map_err(|err| StepError::OutputPin(err))?;
+
+        Ok(())
+    }
+}
+
+/// An error that can occur while setting the microstepping mode
+#[derive(Debug, Eq, PartialEq)]
+pub enum ModeError<OutputPinError> {
+    /// An error originated from using the [`OutputPin`] trait
+    OutputPin(OutputPinError),
+
+    /// An error originated from working with a timer
+    Time(TimeError),
+}
+
+impl<OutputPinError> From<TimeError> for ModeError<OutputPinError> {
+    fn from(err: TimeError) -> Self {
+        Self::Time(err)
+    }
+}
+
+/// An error that can occur while making a step
+#[derive(Debug, Eq, PartialEq)]
+pub enum StepError<OutputPinError> {
+    /// An error originated from using the [`OutputPin`] trait
+    OutputPin(OutputPinError),
+
+    /// An error originated from working with a timer
+    Time(TimeError),
+}
+
+impl<OutputPinError> From<TimeError> for StepError<OutputPinError> {
+    fn from(err: TimeError) -> Self {
+        Self::Time(err)
+    }
+}
+
+/// Provides the pin signals for the given step mode
+fn step_mode_to_signals(
+    step_mode: &StepMode,
+) -> (PinState, PinState, PinState) {
+    use PinState::*;
+    use StepMode::*;
+
+    // FIXME: the DRV8825 only goes down to 1/32 microstepping, but `StepMode`
+    //        goes to 1/256. `M32` - `M256` are currently handled by a
+    //        catch-all in the below `match` block, but this is technically
+    //        incorrect.
+    match step_mode {
+        Full => (Low, Low, Low),
+        M2 => (High, Low, Low),
+        M4 => (Low, High, Low),
+        M8 => (High, High, Low),
+        M16 => (Low, Low, High),
+        _ => (High, High, High),
+    }
+}

--- a/drivers/drv8825/src/lib.rs
+++ b/drivers/drv8825/src/lib.rs
@@ -12,7 +12,4 @@
 #![no_std]
 #![deny(missing_docs)]
 
-pub use step_dir::*;
-
-mod drv8825;
-pub use drv8825::*;
+pub use step_dir::{drv8825::*, *};

--- a/drivers/drv8825/src/lib.rs
+++ b/drivers/drv8825/src/lib.rs
@@ -1,0 +1,18 @@
+//! DRV8825 Driver
+//!
+//! Platform-agnostic driver library for the DRV8825 stepper motor driver.
+//! This crate is a specialized facade of the [Step/Dir] library. Please
+//! consider using Step/Dir directly, as it provides drivers for more stepper
+//! motor drivers, as well as an interface to abstract over them.
+//!
+//! See [Step/Dir] for more documentation and usage examples.
+//!
+//! [Step/Dir]: https://crates.io/crates/step-dir
+
+#![no_std]
+#![deny(missing_docs)]
+
+pub use step_dir::*;
+
+mod drv8825;
+pub use drv8825::*;

--- a/src/drv8825.rs
+++ b/src/drv8825.rs
@@ -75,11 +75,10 @@
 //!
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
 
-use step_dir::{
-    embedded_hal::digital::{OutputPin, PinState},
-    embedded_time::{duration::Nanoseconds, Clock, TimeError},
-    Dir as Direction, SetStepMode, Step as StepTrait, StepMode32,
-};
+use embedded_hal::digital::{OutputPin, PinState};
+use embedded_time::{duration::Nanoseconds, Clock, TimeError};
+
+use crate::{Dir as Direction, SetStepMode, Step as StepTrait, StepMode32};
 
 /// The DRV8825 driver API
 ///

--- a/src/drv8825.rs
+++ b/src/drv8825.rs
@@ -216,9 +216,7 @@ where
             .try_set_low()
             .map_err(|err| ModeError::OutputPin(err))?;
 
-        // Set mode signals. All this repetition is messy. I decided not to do
-        // anything about it and wait for the next embedded-hal alpha version,
-        // which has features that would help here.
+        // Set mode signals.
         let (mode0, mode1, mode2) = step_mode_to_signals(&step_mode);
         self.mode0
             .try_set_state(mode0)
@@ -246,8 +244,8 @@ where
     }
 }
 
-impl<Step, Dir, OutputPinError> StepTrait
-    for DRV8825<(), (), (), (), (), (), (), Step, Dir>
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> StepTrait
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
 where
     Step: OutputPin<Error = OutputPinError>,
     Dir: OutputPin<Error = OutputPinError>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ pub mod prelude {
     pub use super::{SetStepMode as _, Step as _};
 }
 
+#[cfg(feature = "drv8825")]
+pub mod drv8825;
+
 #[cfg(feature = "stspin220")]
 pub mod stspin220;
 


### PR DESCRIPTION
I finally got around to doing some preliminary testing on this, and things are looking promising so far! I've confirmed I can step in either direction at this point, which is a good start. The step mode selection still needs to be tested and verified (I'm not sure I can accurately do this without a test stand), but I just wanted to get some eyes on this in the meantime.

I've included the `Enable`, `Fault`, and `Sleep` pins in the `DRV8825` struct, but they're not currently used for anything. These features can be added whenever `step-dir` has decided on a suitable abstraction for them, I just decided to include them for completeness.

There seems to be a fair bit of duplicate code between this driver and the STSPIN220 driver. It's probably still a bit early, but there may be some additional features/functionality that can be pushed down to `step-dir`. Just something to think about as we continue to move forward.

Whenever you get a chance please let me know what you think of this. Once I have completed testing and we feel it is ready I will convert this from a Draft to a proper PR, I just don't want untested code getting merged accidentally.

Thanks!