### PR TITLE
Bump embedded-time version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
 [dependencies]
 embedded-hal  = "=1.0.0-alpha.4"
-embedded-time = "0.10.0"
+embedded-time = "0.10.1"
 paste         = "1.0.3"
 
 [features]


### PR DESCRIPTION
This is in response to #7.

I was able to reproduce the errors in the [docs.rs build log](https://docs.rs/crate/step-dir/0.3.0/builds/314801) locally. These errors were resolved following the update of _embedded-time_ to `0.10.1`.