### PR TITLE
Introduce `Driver` API

### DIFF
--- a/drivers/drv8825/Cargo.toml
+++ b/drivers/drv8825/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "drv8825"
+name    = "drv8825"
 version = "0.3.0"
 authors = [
     "Hanno Braun <hanno@braun-embedded.com>",

--- a/drivers/drv8825/README.md
+++ b/drivers/drv8825/README.md
@@ -4,13 +4,9 @@
 
 Rust driver crate for the [DRV8825] stepper motor driver. Carrier boards for this chip are [available from Pololu].
 
-This crate is a specialized facade of the [Step/Dir] library. Please consider using Step/Dir directly, as it provides drivers for more stepper motor drivers, as well as an interface to abstract over them.
+This crate is a specialized facade for the [Step/Dir] library. Please consider using Step/Dir directly, as it provides drivers for more stepper motor drivers, as well as an interface to abstract over them.
 
 See [Step/Dir] for more documentation and usage examples.
-
-## Status
-
-This driver is currently very basic in its capabilities. Its design is experimental, and more revisions to the API are expected.
 
 ## License
 
@@ -19,7 +15,7 @@ This project is open source software, licensed under the terms of the [Zero Clau
 See [LICENSE.md] for full details.
 
 [drv8825]: https://www.ti.com/product/DRV8825
-[available from pololu]: https://www.pololu.com/category/154/drv8825-stepper-motor-driver-carriers-high-current
+[available from pololu]: https://www.pololu.com/category/154/
 [step/dir]: https://crates.io/crates/step-dir
 [zero clause bsd license]: https://opensource.org/licenses/0BSD
 [license.md]: https://github.com/braun-embedded/step-dir/blob/master/LICENSE.md

--- a/drivers/drv8825/src/lib.rs
+++ b/drivers/drv8825/src/lib.rs
@@ -1,7 +1,7 @@
 //! DRV8825 Driver
 //!
 //! Platform-agnostic driver library for the DRV8825 stepper motor driver.
-//! This crate is a specialized facade of the [Step/Dir] library. Please
+//! This crate is a specialized facade for the [Step/Dir] library. Please
 //! consider using Step/Dir directly, as it provides drivers for more stepper
 //! motor drivers, as well as an interface to abstract over them.
 //!

--- a/drivers/drv8825/src/lib.rs
+++ b/drivers/drv8825/src/lib.rs
@@ -12,4 +12,4 @@
 #![no_std]
 #![deny(missing_docs)]
 
-pub use step_dir::{drv8825::*, *};
+pub use step_dir::{drivers::drv8825::*, *};

--- a/drivers/stspin220/Cargo.toml
+++ b/drivers/stspin220/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name    = "stspin220"
 version = "0.3.0"
-authors = ["Hanno Braun <hanno@braun-embedded.com>"]
+authors = [
+    "Hanno Braun <hanno@braun-embedded.com>",
+    "Jesse Braham <jesse@beta7.io>",
+]
 edition = "2018"
 
 description = "Driver crate for the STSPIN220 stepper motor driver"

--- a/drivers/stspin220/README.md
+++ b/drivers/stspin220/README.md
@@ -4,13 +4,9 @@
 
 Rust driver crate for the [STSPIN220] stepper motor driver. Carrier boards for this chip are [available from Pololu].
 
-This crate is a specialized facade of the [Step/Dir] library. Please consider using Step/Dir directly, as it provides drivers for more stepper motor drivers, as well as an interface to abstract over them.
+This crate is a specialized facade for the [Step/Dir] library. Please consider using Step/Dir directly, as it provides drivers for more stepper motor drivers, as well as an interface to abstract over them.
 
 See [Step/Dir] for more documentation and usage examples.
-
-## Status
-
-This driver is currently very basic in its capabilities. Its design is experimental, and more revisions to the API are expected.
 
 ## License
 
@@ -19,7 +15,7 @@ This project is open source software, licensed under the terms of the [Zero Clau
 See [LICENSE.md] for full details.
 
 [stspin220]: https://www.st.com/en/motor-drivers/stspin220.html
-[available from pololu]: https://www.pololu.com/category/260/stspin220-low-voltage-stepper-motor-driver-carriers
+[available from pololu]: https://www.pololu.com/category/260/
 [step/dir]: https://crates.io/crates/step-dir
 [zero clause bsd license]: https://opensource.org/licenses/0BSD
 [license.md]: https://github.com/braun-embedded/step-dir/blob/master/LICENSE.md

--- a/drivers/stspin220/src/lib.rs
+++ b/drivers/stspin220/src/lib.rs
@@ -12,4 +12,4 @@
 #![no_std]
 #![deny(missing_docs)]
 
-pub use step_dir::{stspin220::*, *};
+pub use step_dir::{drivers::stspin220::*, *};

--- a/drivers/stspin220/src/lib.rs
+++ b/drivers/stspin220/src/lib.rs
@@ -1,7 +1,7 @@
 //! STSPIN220 Driver
 //!
 //! Platform-agnostic driver library for the STSPIN220 stepper motor driver.
-//! This crate is a specialized facade of the [Step/Dir] library. Please
+//! This crate is a specialized facade for the [Step/Dir] library. Please
 //! consider using Step/Dir directly, as it provides drivers for more stepper
 //! motor drivers, as well as an interface to abstract over them.
 //!

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,6 +1,9 @@
 use embedded_time::{Clock, TimeError};
 
-use crate::{Dir, SetStepMode, Step};
+use crate::{
+    traits::{SetStepMode, Step},
+    Dir,
+};
 
 /// Abstract interface to stepper motor drivers
 ///

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,5 +1,47 @@
 use embedded_time::TimeError;
 
+/// Abstract interface to stepper motor drivers
+///
+/// Wraps a concrete driver and uses the traits that the concrete driver
+/// implements to provide an abstract API.
+pub struct Driver<T> {
+    inner: T,
+}
+
+impl<T> Driver<T> {
+    /// Create a new `Driver` instance from a concrete driver
+    ///
+    /// Since `Driver` only provides an abstract interface for _using_ a driver,
+    /// not for initializing it, you have to initialize a concrete driver and
+    /// pass it to this constructor.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Access a reference to the wrapped driver
+    ///
+    /// Can be used to access driver-specific functionality that can't be
+    /// provided by `Driver`'s abstract interface.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Access a mutable reference to the wrapped driver
+    ///
+    /// Can be used to access driver-specific functionality that can't be
+    /// provided by `Driver`'s abstract interface.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Release the wrapped driver
+    ///
+    /// Drops this instance of `Driver` and returns the wrapped driver.
+    pub fn release(self) -> T {
+        self.inner
+    }
+}
+
 /// An error that can occur while setting the microstepping mode
 #[derive(Debug, Eq, PartialEq)]
 pub enum ModeError<OutputPinError> {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,37 @@
+use embedded_time::TimeError;
+
+/// An error that can occur while setting the microstepping mode
+#[derive(Debug, Eq, PartialEq)]
+pub enum ModeError<OutputPinError> {
+    /// An error originated from using the [`OutputPin`] trait
+    ///
+    /// [`OutputPin`]: embedded_hal::digital::OutputPin
+    OutputPin(OutputPinError),
+
+    /// An error originated from working with a timer
+    Time(TimeError),
+}
+
+impl<OutputPinError> From<TimeError> for ModeError<OutputPinError> {
+    fn from(err: TimeError) -> Self {
+        Self::Time(err)
+    }
+}
+
+/// An error that can occur while making a step
+#[derive(Debug, Eq, PartialEq)]
+pub enum StepError<OutputPinError> {
+    /// An error originated from using the [`OutputPin`] trait
+    ///
+    /// [`OutputPin`]: embedded_hal::digital::OutputPin
+    OutputPin(OutputPinError),
+
+    /// An error originated from working with a timer
+    Time(TimeError),
+}
+
+impl<OutputPinError> From<TimeError> for StepError<OutputPinError> {
+    fn from(err: TimeError) -> Self {
+        Self::Time(err)
+    }
+}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -84,12 +84,12 @@ impl<T> Driver<T> {
         match dir {
             Dir::Forward => self
                 .inner
-                .dir_pin()
+                .dir()
                 .try_set_high()
                 .map_err(|err| StepError::OutputPin(err))?,
             Dir::Backward => self
                 .inner
-                .dir_pin()
+                .dir()
                 .try_set_low()
                 .map_err(|err| StepError::OutputPin(err))?,
         }
@@ -98,7 +98,7 @@ impl<T> Driver<T> {
 
         // Start step pulse
         self.inner
-            .step_pin()
+            .step()
             .try_set_high()
             .map_err(|err| StepError::OutputPin(err))?;
 
@@ -106,7 +106,7 @@ impl<T> Driver<T> {
 
         // End step pulse
         self.inner
-            .step_pin()
+            .step()
             .try_set_low()
             .map_err(|err| StepError::OutputPin(err))?;
 

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -264,11 +264,11 @@ where
     type Step = Step;
     type Error = OutputPinError;
 
-    fn dir_pin(&mut self) -> &mut Self::Dir {
+    fn dir(&mut self) -> &mut Self::Dir {
         &mut self.dir
     }
 
-    fn step_pin(&mut self) -> &mut Self::Step {
+    fn step(&mut self) -> &mut Self::Step {
         &mut self.step
     }
 }

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -81,8 +81,8 @@ use embedded_hal::digital::{OutputPin, PinState};
 use embedded_time::{duration::Nanoseconds, Clock};
 
 use crate::{
-    Dir as Direction, ModeError, SetStepMode, Step as StepTrait, StepError,
-    StepMode32,
+    traits::{SetStepMode, Step as StepTrait},
+    Dir as Direction, ModeError, StepError, StepMode32,
 };
 
 /// The DRV8825 driver API

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -260,7 +260,17 @@ where
     const SETUP_TIME: Nanoseconds = Nanoseconds(650);
     const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
 
+    type Dir = Dir;
+    type Step = Step;
     type Error = StepError<OutputPinError>;
+
+    fn dir_pin(&mut self) -> &mut Self::Dir {
+        &mut self.dir
+    }
+
+    fn step_pin(&mut self) -> &mut Self::Step {
+        &mut self.step
+    }
 
     /// Rotates the motor one (micro-)step in the given direction
     ///
@@ -286,11 +296,11 @@ where
     ) -> Result<(), Self::Error> {
         match dir {
             Direction::Forward => self
-                .dir
+                .dir_pin()
                 .try_set_high()
                 .map_err(|err| StepError::OutputPin(err))?,
             Direction::Backward => self
-                .dir
+                .dir_pin()
                 .try_set_low()
                 .map_err(|err| StepError::OutputPin(err))?,
         }
@@ -300,7 +310,7 @@ where
         clock.new_timer(Self::SETUP_TIME).start()?.wait()?;
 
         // Start step pulse
-        self.step
+        self.step_pin()
             .try_set_high()
             .map_err(|err| StepError::OutputPin(err))?;
 
@@ -310,7 +320,7 @@ where
         clock.new_timer(Self::PULSE_LENGTH).start()?.wait()?;
 
         // End step pulse
-        self.step
+        self.step_pin()
             .try_set_low()
             .map_err(|err| StepError::OutputPin(err))?;
 

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -12,7 +12,7 @@
 //! # fn main()
 //! #     -> Result<
 //! #         (),
-//! #         step_dir::drivers::drv8825::StepError<core::convert::Infallible>
+//! #         step_dir::StepError<core::convert::Infallible>
 //! #     > {
 //! #
 //! use step_dir::{
@@ -76,9 +76,12 @@
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
 
 use embedded_hal::digital::{OutputPin, PinState};
-use embedded_time::{duration::Nanoseconds, Clock, TimeError};
+use embedded_time::{duration::Nanoseconds, Clock};
 
-use crate::{Dir as Direction, SetStepMode, Step as StepTrait, StepMode32};
+use crate::{
+    Dir as Direction, ModeError, SetStepMode, Step as StepTrait, StepError,
+    StepMode32,
+};
 
 /// The DRV8825 driver API
 ///
@@ -310,38 +313,6 @@ where
             .map_err(|err| StepError::OutputPin(err))?;
 
         Ok(())
-    }
-}
-
-/// An error that can occur while setting the microstepping mode
-#[derive(Debug, Eq, PartialEq)]
-pub enum ModeError<OutputPinError> {
-    /// An error originated from using the [`OutputPin`] trait
-    OutputPin(OutputPinError),
-
-    /// An error originated from working with a timer
-    Time(TimeError),
-}
-
-impl<OutputPinError> From<TimeError> for ModeError<OutputPinError> {
-    fn from(err: TimeError) -> Self {
-        Self::Time(err)
-    }
-}
-
-/// An error that can occur while making a step
-#[derive(Debug, Eq, PartialEq)]
-pub enum StepError<OutputPinError> {
-    /// An error originated from using the [`OutputPin`] trait
-    OutputPin(OutputPinError),
-
-    /// An error originated from working with a timer
-    Time(TimeError),
-}
-
-impl<OutputPinError> From<TimeError> for StepError<OutputPinError> {
-    fn from(err: TimeError) -> Self {
-        Self::Time(err)
     }
 }
 

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -255,6 +255,11 @@ where
     Step: OutputPin<Error = OutputPinError>,
     Dir: OutputPin<Error = OutputPinError>,
 {
+    // 7.6 Timing Requirements (page 7)
+    // https://www.ti.com/lit/ds/symlink/drv8825.pdf
+    const SETUP_TIME: Nanoseconds = Nanoseconds(650);
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
+
     type Error = StepError<OutputPinError>;
 
     /// Rotates the motor one (micro-)step in the given direction
@@ -279,11 +284,6 @@ where
         dir: Direction,
         clock: &Clk,
     ) -> Result<(), Self::Error> {
-        // 7.6 Timing Requirements (page 7)
-        // https://www.ti.com/lit/ds/symlink/drv8825.pdf
-        const SETUP_TIME: Nanoseconds = Nanoseconds(650);
-        const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
-
         match dir {
             Direction::Forward => self
                 .dir
@@ -297,7 +297,7 @@ where
 
         // According to the datasheet, we need to wait at least 650ns between
         // setting DIR and starting the STEP pulse
-        clock.new_timer(SETUP_TIME).start()?.wait()?;
+        clock.new_timer(Self::SETUP_TIME).start()?.wait()?;
 
         // Start step pulse
         self.step
@@ -307,7 +307,7 @@ where
         // There are two delays we need to adhere to:
         // - The minimum DIR hold time of 650ns
         // - The minimum STEP high time of 1.9us
-        clock.new_timer(PULSE_LENGTH).start()?.wait()?;
+        clock.new_timer(Self::PULSE_LENGTH).start()?.wait()?;
 
         // End step pulse
         self.step

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -18,7 +18,7 @@
 //! use step_dir::{
 //!     embedded_time::{duration::Microseconds, Clock as _},
 //!     drivers::drv8825::DRV8825,
-//!     Dir, Step as _,
+//!     Dir, Driver,
 //! };
 //!
 //! const STEP_DELAY: Microseconds = Microseconds(500);
@@ -59,7 +59,9 @@
 //! // need an implementation of `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP and DIR pins.
-//! let mut driver = DRV8825::from_step_dir_pins(step, dir);
+//! let mut driver = Driver::new(
+//!     DRV8825::from_step_dir_pins(step, dir)
+//! );
 //!
 //! // Rotate stepper motor by a few steps.
 //! for _ in 0 .. 5 {

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -1,10 +1,10 @@
-//! STSPIN220 Driver
+//! DRV8825 Driver
 //!
-//! Platform-agnostic driver for the STSPIN220 stepper motor driver. This module
+//! Platform-agnostic driver for the DRV8825 stepper motor driver. This module
 //! can be used on any platform for which implementations of the required
 //! [embedded-hal] traits are available.
 //!
-//! The entry point to this module is the [`STSPIN220`] struct.
+//! The entry point to this module is the [`DRV8825`] struct.
 //!
 //! # Example
 //!
@@ -12,12 +12,12 @@
 //! # fn main()
 //! #     -> Result<
 //! #         (),
-//! #         step_dir::stspin220::StepError<core::convert::Infallible>
+//! #         step_dir::drivers::drv8825::StepError<core::convert::Infallible>
 //! #     > {
 //! #
 //! use step_dir::{
 //!     embedded_time::{duration::Microseconds, Clock as _},
-//!     stspin220::STSPIN220,
+//!     drivers::drv8825::DRV8825,
 //!     Dir, Step as _,
 //! };
 //!
@@ -49,18 +49,17 @@
 //! #     }
 //! # }
 //! #
-//! # let step_mode3 = Pin;
-//! # let dir_mode4 = Pin;
+//! # let step = Pin;
+//! # let dir = Pin;
 //! # let mut clock = Clock(std::time::Instant::now());
 //! #
-//! // You need to acquire the GPIO pins connected to the STEP/MODE3 and
-//! // DIR/MODE4 signals. How you do this depends on your target platform. All
-//! // the driver cares about is that they implement
-//! // `embedded_hal::digital::OutputPin`. You also need an implementation of
-//! // `embedded_hal::blocking::DelayUs`.
+//! // You need to acquire the GPIO pins connected to the STEP and DIR signals.
+//! // How you do this depends on your target platform. All the driver cares
+//! // about is that they implement `embedded_hal::digital::OutputPin`. You also
+//! // need an implementation of `embedded_hal::blocking::DelayUs`.
 //!
-//! // Create driver API from STEP/MODE3 and DIR/MODE4 pins.
-//! let mut driver = STSPIN220::from_step_dir_pins(step_mode3, dir_mode4);
+//! // Create driver API from STEP and DIR pins.
+//! let mut driver = DRV8825::from_step_dir_pins(step, dir);
 //!
 //! // Rotate stepper motor by a few steps.
 //! for _ in 0 .. 5 {
@@ -77,114 +76,109 @@
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
 
 use embedded_hal::digital::{OutputPin, PinState};
-use embedded_time::{
-    duration::{Microseconds, Nanoseconds},
-    Clock, TimeError,
-};
+use embedded_time::{duration::Nanoseconds, Clock, TimeError};
 
-use crate::{Dir, SetStepMode, Step, StepMode256};
+use crate::{Dir as Direction, SetStepMode, Step as StepTrait, StepMode32};
 
-/// The STSPIN220 driver API
+/// The DRV8825 driver API
 ///
 /// You can create an instance of this struct by calling
-/// [`STSPIN220::from_step_dir_pins`]. See [module documentation] for a full
+/// [`DRV8825::from_step_dir_pins`]. See [module documentation] for a full
 /// example that uses this API.
 ///
 /// [module documentation]: index.html
-pub struct STSPIN220<
-    EnableFault,
-    StandbyReset,
-    Mode1,
-    Mode2,
-    StepMode3,
-    DirMode4,
-> {
-    enable_fault: EnableFault,
-    standby_reset: StandbyReset,
+pub struct DRV8825<Enable, Fault, Sleep, Reset, Mode0, Mode1, Mode2, Step, Dir>
+{
+    enable: Enable,
+    fault: Fault,
+    sleep: Sleep,
+    reset: Reset,
+    mode0: Mode0,
     mode1: Mode1,
     mode2: Mode2,
-    step_mode3: StepMode3,
-    dir_mode4: DirMode4,
+    step: Step,
+    dir: Dir,
 }
 
-impl<StepMode3, DirMode4> STSPIN220<(), (), (), (), StepMode3, DirMode4> {
-    /// Create a new instance of `STSPIN220`
+impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
+    /// Create a new instance of `DRV8825`
     ///
-    /// Creates an instance of this struct from just the STEP/MODE3 and
-    /// DIR/MODE4 pins. It expects the types that represent those pins to
-    /// implement [`OutputPin`].
+    /// Creates an instance of this struct from just the STEP and DIR pins. It
+    /// expects the types that represent those pins to implement [`OutputPin`].
     ///
     /// The resulting instance can be used to step the motor using
-    /// [`STSPIN220::step`]. All other capabilities of the STSPIN220, like
+    /// [`DRV8825::step`]. All other capabilities of the DRV8825, like
     /// the power-up sequence, selecting a step mode, or controlling the power
     /// state, explicitly enabled, or managed externally.
     ///
     /// To enable additional capabilities, see
-    /// [`STSPIN220::enable_mode_control`].
-    pub fn from_step_dir_pins<Error>(
-        step_mode3: StepMode3,
-        dir_mode4: DirMode4,
-    ) -> Self
+    /// [`DRV8825::enable_mode_control`].
+    pub fn from_step_dir_pins<Error>(step: Step, dir: Dir) -> Self
     where
-        StepMode3: OutputPin<Error = Error>,
-        DirMode4: OutputPin<Error = Error>,
+        Step: OutputPin<Error = Error>,
+        Dir: OutputPin<Error = Error>,
     {
         Self {
-            enable_fault: (),
-            standby_reset: (),
+            enable: (),
+            fault: (),
+            sleep: (),
+            reset: (),
+            mode0: (),
             mode1: (),
             mode2: (),
-            step_mode3,
-            dir_mode4,
+            step,
+            dir,
         }
     }
 }
 
-impl<EnableFault, StepMode3, DirMode4>
-    STSPIN220<EnableFault, (), (), (), StepMode3, DirMode4>
-{
+impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
     /// Enables support for step mode control and sets the initial step mode
     ///
-    /// Consumes this instance of `STSPIN220` and returns another instance that
+    /// Consumes this instance of `DRV8825` and returns another instance that
     /// has support for controlling the step mode. Requires the additional pins
-    /// for doing so, namely STBY/RESET, MODE1, and MODE2. It expects the types
-    /// that represent those pins to implement [`OutputPin`].
+    /// for doing so, namely RESET, MODE0, MODE1, and MODE2. It expects the
+    /// types that represent those pins to implement [`OutputPin`].
     ///
     /// This method is only available when those pins have not been provided
     /// yet. After this method has been called once, you can use
-    /// [`STSPIN220::set_step_mode`] to change the step mode again.
+    /// [`DRV8825::set_step_mode`] to change the step mode again.
     pub fn enable_mode_control<
-        StandbyReset,
+        Reset,
+        Mode0,
         Mode1,
         Mode2,
         Clk,
         OutputPinError,
     >(
         self,
-        standby_reset: StandbyReset,
+        reset: Reset,
+        mode0: Mode0,
         mode1: Mode1,
         mode2: Mode2,
-        step_mode: StepMode256,
+        step_mode: StepMode32,
         clock: &Clk,
     ) -> Result<
-        STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>,
+        DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>,
         ModeError<OutputPinError>,
     >
     where
-        StandbyReset: OutputPin<Error = OutputPinError>,
+        Reset: OutputPin<Error = OutputPinError>,
+        Mode0: OutputPin<Error = OutputPinError>,
         Mode1: OutputPin<Error = OutputPinError>,
         Mode2: OutputPin<Error = OutputPinError>,
-        StepMode3: OutputPin<Error = OutputPinError>,
-        DirMode4: OutputPin<Error = OutputPinError>,
         Clk: Clock,
     {
-        let mut self_ = STSPIN220 {
-            enable_fault: self.enable_fault,
-            standby_reset,
+        let mut self_ = DRV8825 {
+            enable: self.enable,
+            fault: self.fault,
+            sleep: self.sleep,
+            reset,
+            mode0,
             mode1,
             mode2,
-            step_mode3: self.step_mode3,
-            dir_mode4: self.dir_mode4,
+            step: self.step,
+            dir: self.dir,
         };
 
         self_.set_step_mode(step_mode, clock)?;
@@ -193,96 +187,76 @@ impl<EnableFault, StepMode3, DirMode4>
     }
 }
 
-impl<
-        EnableFault,
-        StandbyReset,
-        Mode1,
-        Mode2,
-        StepMode3,
-        DirMode4,
-        OutputPinError,
-    > SetStepMode
-    for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> SetStepMode
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
 where
-    StandbyReset: OutputPin<Error = OutputPinError>,
+    Reset: OutputPin<Error = OutputPinError>,
+    Mode0: OutputPin<Error = OutputPinError>,
     Mode1: OutputPin<Error = OutputPinError>,
     Mode2: OutputPin<Error = OutputPinError>,
-    StepMode3: OutputPin<Error = OutputPinError>,
-    DirMode4: OutputPin<Error = OutputPinError>,
 {
     type Error = ModeError<OutputPinError>;
-
-    type StepMode = StepMode256;
+    type StepMode = StepMode32;
 
     /// Sets the step mode
     ///
     /// This method is only available, if all the pins required for setting the
-    /// step mode have been provided using [`STSPIN220::enable_mode_control`].
+    /// step mode have been provided using [`DRV8825::enable_mode_control`].
     fn set_step_mode<Clk: Clock>(
         &mut self,
-        step_mode: Self::StepMode,
+        step_mode: StepMode32,
         clock: &Clk,
     ) -> Result<(), Self::Error> {
-        const MODE_SETUP_TIME: Microseconds = Microseconds(1);
-        const MODE_HOLD_TIME: Microseconds = Microseconds(100);
+        // 7.6 Timing Requirements (page 7)
+        // https://www.ti.com/lit/ds/symlink/drv8825.pdf
+        const SETUP_TIME: Nanoseconds = Nanoseconds(650);
 
-        // Force driver into standby mode.
-        self.standby_reset
+        // Reset the device's internal logic and disable the h-bridge drivers.
+        self.reset
             .try_set_low()
             .map_err(|err| ModeError::OutputPin(err))?;
 
         // Set mode signals.
-        let (mode1, mode2, mode3, mode4) = step_mode_to_signals(&step_mode);
+        let (mode0, mode1, mode2) = step_mode_to_signals(&step_mode);
+        self.mode0
+            .try_set_state(mode0)
+            .map_err(|err| ModeError::OutputPin(err))?;
         self.mode1
             .try_set_state(mode1)
             .map_err(|err| ModeError::OutputPin(err))?;
         self.mode2
             .try_set_state(mode2)
             .map_err(|err| ModeError::OutputPin(err))?;
-        self.step_mode3
-            .try_set_state(mode3)
-            .map_err(|err| ModeError::OutputPin(err))?;
-        self.dir_mode4
-            .try_set_state(mode4)
-            .map_err(|err| ModeError::OutputPin(err))?;
 
         // Need to wait for the MODEx input setup time.
-        clock.new_timer(MODE_SETUP_TIME).start()?.wait()?;
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
 
-        // Leave standby mode.
-        self.standby_reset
+        // Re-enable the h-bridge drivers using the new configuration.
+        self.reset
             .try_set_high()
             .map_err(|err| ModeError::OutputPin(err))?;
 
         // Now the mode pins need to stay as they are for the MODEx input hold
         // time, for the settings to take effect.
-        clock.new_timer(MODE_HOLD_TIME).start()?.wait()?;
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
 
         Ok(())
     }
 }
 
-impl<
-        EnableFault,
-        StandbyReset,
-        Mode1,
-        Mode2,
-        StepMode3,
-        DirMode4,
-        OutputPinError,
-    > Step
-    for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> StepTrait
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
 where
-    StepMode3: OutputPin<Error = OutputPinError>,
-    DirMode4: OutputPin<Error = OutputPinError>,
+    Step: OutputPin<Error = OutputPinError>,
+    Dir: OutputPin<Error = OutputPinError>,
 {
     type Error = StepError<OutputPinError>;
 
     /// Rotates the motor one (micro-)step in the given direction
     ///
-    /// Sets the DIR/MODE4 pin according to the `dir` argument, initiates a step
-    /// pulse by setting STEP/MODE3 HIGH, then ends the step pulse by setting
-    /// STEP/MODE4 LOW again. The method blocks while this is going on.
+    /// Sets the DIR pin according to the `dir` argument, initiates a step pulse
+    /// by setting STEP HIGH, then ends the step pulse by setting STEP LOW
+    /// again. The method blocks while this is going on.
     ///
     /// This should result in the motor making one step. To achieve a specific
     /// speed, the user must call this method at the appropriate frequency.
@@ -293,66 +267,49 @@ where
     ///
     /// Any errors that occur are wrapped in a [`StepError`] and returned to the
     /// user directly. This might leave the driver API in an invalid state, for
-    /// example if STEP/MODE3 has been set HIGH, but an error occurs before it
-    /// can be set LOW again.
+    /// example if STEP has been set HIGH, but an error occurs before it can be
+    /// set LOW again.
     fn step<Clk: Clock>(
         &mut self,
-        dir: Dir,
+        dir: Direction,
         clock: &Clk,
     ) -> Result<(), Self::Error> {
-        const DIR_SETUP_DELAY: Nanoseconds = Nanoseconds(100);
-        const PULSE_LENGTH: Nanoseconds = Nanoseconds(100);
+        // 7.6 Timing Requirements (page 7)
+        // https://www.ti.com/lit/ds/symlink/drv8825.pdf
+        const SETUP_TIME: Nanoseconds = Nanoseconds(650);
+        const PULSE_LENGTH: Nanoseconds = Nanoseconds(1900);
 
         match dir {
-            Dir::Forward => self
-                .dir_mode4
+            Direction::Forward => self
+                .dir
                 .try_set_high()
                 .map_err(|err| StepError::OutputPin(err))?,
-            Dir::Backward => self
-                .dir_mode4
+            Direction::Backward => self
+                .dir
                 .try_set_low()
                 .map_err(|err| StepError::OutputPin(err))?,
         }
 
-        // According to the datasheet, we need to wait at least 100 ns between
-        // setting DIR and starting the STEP pulse.
-        clock.new_timer(DIR_SETUP_DELAY).start()?.wait()?;
+        // According to the datasheet, we need to wait at least 650ns between
+        // setting DIR and starting the STEP pulse
+        clock.new_timer(SETUP_TIME).start()?.wait()?;
 
         // Start step pulse
-        self.step_mode3
+        self.step
             .try_set_high()
             .map_err(|err| StepError::OutputPin(err))?;
 
         // There are two delays we need to adhere to:
-        // - The minimum DIR hold time of 100 ns.
-        // - The minimum STCK high time, also 100 ns.
+        // - The minimum DIR hold time of 650ns
+        // - The minimum STEP high time of 1.9us
         clock.new_timer(PULSE_LENGTH).start()?.wait()?;
 
         // End step pulse
-        self.step_mode3
+        self.step
             .try_set_low()
             .map_err(|err| StepError::OutputPin(err))?;
 
         Ok(())
-    }
-}
-
-/// Provides the pin signals for the given step mode
-pub fn step_mode_to_signals(
-    step_mode: &StepMode256,
-) -> (PinState, PinState, PinState, PinState) {
-    use PinState::*;
-    use StepMode256::*;
-    match step_mode {
-        Full => (Low, Low, Low, Low),
-        M2 => (High, Low, High, Low),
-        M4 => (Low, High, Low, High),
-        M8 => (High, High, High, Low),
-        M16 => (High, High, High, High),
-        M32 => (Low, High, Low, Low),
-        M64 => (High, High, Low, High),
-        M128 => (High, Low, Low, Low),
-        M256 => (High, High, Low, Low),
     }
 }
 
@@ -385,5 +342,22 @@ pub enum StepError<OutputPinError> {
 impl<OutputPinError> From<TimeError> for StepError<OutputPinError> {
     fn from(err: TimeError) -> Self {
         Self::Time(err)
+    }
+}
+
+/// Provides the pin signals for the given step mode
+fn step_mode_to_signals(
+    step_mode: &StepMode32,
+) -> (PinState, PinState, PinState) {
+    use PinState::*;
+    use StepMode32::*;
+
+    match step_mode {
+        Full => (Low, Low, Low),
+        M2 => (High, Low, Low),
+        M4 => (Low, High, Low),
+        M8 => (High, High, Low),
+        M16 => (Low, Low, High),
+        M32 => (High, High, High),
     }
 }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,0 +1,12 @@
+//! Parent module for all driver implementations
+//!
+//! This module contains the driver implementations that are currently supported
+//! by Step/Dir. Each sub-module is behind a feature gate, to allow users to
+//! only enable the drivers they actually need. By default, all drivers are
+//! enabled.
+
+#[cfg(feature = "drv8825")]
+pub mod drv8825;
+
+#[cfg(feature = "stspin220")]
+pub mod stspin220;

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -284,7 +284,17 @@ where
     const SETUP_TIME: Nanoseconds = Nanoseconds(100);
     const PULSE_LENGTH: Nanoseconds = Nanoseconds(100);
 
+    type Dir = DirMode4;
+    type Step = StepMode3;
     type Error = StepError<OutputPinError>;
+
+    fn dir_pin(&mut self) -> &mut Self::Dir {
+        &mut self.dir_mode4
+    }
+
+    fn step_pin(&mut self) -> &mut Self::Step {
+        &mut self.step_mode3
+    }
 
     /// Rotates the motor one (micro-)step in the given direction
     ///
@@ -310,11 +320,11 @@ where
     ) -> Result<(), Self::Error> {
         match dir {
             Dir::Forward => self
-                .dir_mode4
+                .dir_pin()
                 .try_set_high()
                 .map_err(|err| StepError::OutputPin(err))?,
             Dir::Backward => self
-                .dir_mode4
+                .dir_pin()
                 .try_set_low()
                 .map_err(|err| StepError::OutputPin(err))?,
         }
@@ -324,7 +334,7 @@ where
         clock.new_timer(Self::SETUP_TIME).start()?.wait()?;
 
         // Start step pulse
-        self.step_mode3
+        self.step_pin()
             .try_set_high()
             .map_err(|err| StepError::OutputPin(err))?;
 
@@ -334,7 +344,7 @@ where
         clock.new_timer(Self::PULSE_LENGTH).start()?.wait()?;
 
         // End step pulse
-        self.step_mode3
+        self.step_pin()
             .try_set_low()
             .map_err(|err| StepError::OutputPin(err))?;
 

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -18,7 +18,7 @@
 //! use step_dir::{
 //!     embedded_time::{duration::Microseconds, Clock as _},
 //!     drivers::stspin220::STSPIN220,
-//!     Dir, Step as _,
+//!     Dir, Driver,
 //! };
 //!
 //! const STEP_DELAY: Microseconds = Microseconds(500);
@@ -60,7 +60,9 @@
 //! // `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP/MODE3 and DIR/MODE4 pins.
-//! let mut driver = STSPIN220::from_step_dir_pins(step_mode3, dir_mode4);
+//! let mut driver = Driver::new(
+//!     STSPIN220::from_step_dir_pins(step_mode3, dir_mode4)
+//! );
 //!
 //! // Rotate stepper motor by a few steps.
 //! for _ in 0 .. 5 {

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -288,11 +288,11 @@ where
     type Step = StepMode3;
     type Error = OutputPinError;
 
-    fn dir_pin(&mut self) -> &mut Self::Dir {
+    fn dir(&mut self) -> &mut Self::Dir {
         &mut self.dir_mode4
     }
 
-    fn step_pin(&mut self) -> &mut Self::Step {
+    fn step(&mut self) -> &mut Self::Step {
         &mut self.step_mode3
     }
 }

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -281,6 +281,9 @@ where
     StepMode3: OutputPin<Error = OutputPinError>,
     DirMode4: OutputPin<Error = OutputPinError>,
 {
+    const SETUP_TIME: Nanoseconds = Nanoseconds(100);
+    const PULSE_LENGTH: Nanoseconds = Nanoseconds(100);
+
     type Error = StepError<OutputPinError>;
 
     /// Rotates the motor one (micro-)step in the given direction
@@ -305,9 +308,6 @@ where
         dir: Dir,
         clock: &Clk,
     ) -> Result<(), Self::Error> {
-        const DIR_SETUP_DELAY: Nanoseconds = Nanoseconds(100);
-        const PULSE_LENGTH: Nanoseconds = Nanoseconds(100);
-
         match dir {
             Dir::Forward => self
                 .dir_mode4
@@ -321,7 +321,7 @@ where
 
         // According to the datasheet, we need to wait at least 100 ns between
         // setting DIR and starting the STEP pulse.
-        clock.new_timer(DIR_SETUP_DELAY).start()?.wait()?;
+        clock.new_timer(Self::SETUP_TIME).start()?.wait()?;
 
         // Start step pulse
         self.step_mode3
@@ -331,7 +331,7 @@ where
         // There are two delays we need to adhere to:
         // - The minimum DIR hold time of 100 ns.
         // - The minimum STCK high time, also 100 ns.
-        clock.new_timer(PULSE_LENGTH).start()?.wait()?;
+        clock.new_timer(Self::PULSE_LENGTH).start()?.wait()?;
 
         // End step pulse
         self.step_mode3

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -84,7 +84,10 @@ use embedded_time::{
     Clock,
 };
 
-use crate::{Dir, ModeError, SetStepMode, Step, StepError, StepMode256};
+use crate::{
+    traits::{SetStepMode, Step},
+    Dir, ModeError, StepError, StepMode256,
+};
 
 /// The STSPIN220 driver API
 ///

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -12,7 +12,7 @@
 //! # fn main()
 //! #     -> Result<
 //! #         (),
-//! #         step_dir::drivers::stspin220::StepError<core::convert::Infallible>
+//! #         step_dir::StepError<core::convert::Infallible>
 //! #     > {
 //! #
 //! use step_dir::{
@@ -79,10 +79,10 @@
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_time::{
     duration::{Microseconds, Nanoseconds},
-    Clock, TimeError,
+    Clock,
 };
 
-use crate::{Dir, SetStepMode, Step, StepMode256};
+use crate::{Dir, ModeError, SetStepMode, Step, StepError, StepMode256};
 
 /// The STSPIN220 driver API
 ///
@@ -353,37 +353,5 @@ pub fn step_mode_to_signals(
         M64 => (High, High, Low, High),
         M128 => (High, Low, Low, Low),
         M256 => (High, High, Low, Low),
-    }
-}
-
-/// An error that can occur while setting the microstepping mode
-#[derive(Debug, Eq, PartialEq)]
-pub enum ModeError<OutputPinError> {
-    /// An error originated from using the [`OutputPin`] trait
-    OutputPin(OutputPinError),
-
-    /// An error originated from working with a timer
-    Time(TimeError),
-}
-
-impl<OutputPinError> From<TimeError> for ModeError<OutputPinError> {
-    fn from(err: TimeError) -> Self {
-        Self::Time(err)
-    }
-}
-
-/// An error that can occur while making a step
-#[derive(Debug, Eq, PartialEq)]
-pub enum StepError<OutputPinError> {
-    /// An error originated from using the [`OutputPin`] trait
-    OutputPin(OutputPinError),
-
-    /// An error originated from working with a timer
-    Time(TimeError),
-}
-
-impl<OutputPinError> From<TimeError> for StepError<OutputPinError> {
-    fn from(err: TimeError) -> Self {
-        Self::Time(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,55 +28,16 @@ pub extern crate embedded_time;
 
 /// Re-exports the traits from this library
 pub mod prelude {
-    pub use super::{SetStepMode as _, Step as _};
+    pub use crate::traits::{SetStepMode as _, Step as _};
 }
 
 pub mod drivers;
+pub mod traits;
 
 mod driver;
 mod step_mode;
 
 pub use self::{driver::*, step_mode::*};
-
-use embedded_time::Clock;
-
-/// Blocking interface for setting the step mode
-pub trait SetStepMode {
-    /// The error that can occur while using this trait
-    type Error;
-
-    /// The type that defines the microstepping mode
-    ///
-    /// This crate includes a number of enums that can be used for this purpose.
-    type StepMode: StepMode;
-
-    /// Sets the step mode
-    fn set_step_mode<Clk: Clock>(
-        &mut self,
-        step_mode: Self::StepMode,
-        clock: &Clk,
-    ) -> Result<(), Self::Error>;
-}
-
-/// Blocking interface for making single steps
-pub trait Step {
-    /// The error that can occur while using this trait
-    type Error;
-
-    /// Rotates the motor one (micro-)step in the given direction
-    ///
-    /// This should result in the motor making one step. To achieve a specific
-    /// speed, the user must call this method at the appropriate frequency.
-    ///
-    /// Requires a reference to an `embedded_time::Clock` implementation to
-    /// handle the timing. Please make sure that the timer doesn't overflow
-    /// while this method is running.
-    fn step<Clk: Clock>(
-        &mut self,
-        dir: Dir,
-        clock: &Clk,
-    ) -> Result<(), Self::Error>;
-}
 
 /// Defines the direction in which to rotate the motor
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,6 @@
 pub extern crate embedded_hal;
 pub extern crate embedded_time;
 
-/// Re-exports the traits from this library
-pub mod prelude {
-    pub use crate::traits::{SetStepMode as _, Step as _};
-}
-
 pub mod drivers;
 pub mod traits;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,10 @@ pub mod prelude {
 
 pub mod drivers;
 
+mod driver;
 mod step_mode;
 
-pub use self::step_mode::*;
+pub use self::{driver::*, step_mode::*};
 
 use embedded_time::Clock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! Right now, Step/Dir supports the following drivers:
 //!
-//! - [DRV8825](crate::drv8825::DRV8825)
-//! - [STSPIN220](crate::stspin220::STSPIN220)
+//! - [DRV8825](crate::drivers::drv8825::DRV8825)
+//! - [STSPIN220](crate::drivers::stspin220::STSPIN220)
 //!
 //! Step/Dir defines traits that allow users to write code that is completely
 //! agnostic to the stepper motor driver it controls. Currently these traits are
@@ -31,11 +31,7 @@ pub mod prelude {
     pub use super::{SetStepMode as _, Step as _};
 }
 
-#[cfg(feature = "drv8825")]
-pub mod drv8825;
-
-#[cfg(feature = "stspin220")]
-pub mod stspin220;
+pub mod drivers;
 
 mod step_mode;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,43 @@
+//! Contains traits that can be implemented by Step/Dir drivers
+
+use embedded_time::Clock;
+
+use crate::{Dir, StepMode};
+
+/// Blocking interface for setting the step mode
+pub trait SetStepMode {
+    /// The error that can occur while using this trait
+    type Error;
+
+    /// The type that defines the microstepping mode
+    ///
+    /// This crate includes a number of enums that can be used for this purpose.
+    type StepMode: StepMode;
+
+    /// Sets the step mode
+    fn set_step_mode<Clk: Clock>(
+        &mut self,
+        step_mode: Self::StepMode,
+        clock: &Clk,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Blocking interface for making single steps
+pub trait Step {
+    /// The error that can occur while using this trait
+    type Error;
+
+    /// Rotates the motor one (micro-)step in the given direction
+    ///
+    /// This should result in the motor making one step. To achieve a specific
+    /// speed, the user must call this method at the appropriate frequency.
+    ///
+    /// Requires a reference to an `embedded_time::Clock` implementation to
+    /// handle the timing. Please make sure that the timer doesn't overflow
+    /// while this method is running.
+    fn step<Clk: Clock>(
+        &mut self,
+        dir: Dir,
+        clock: &Clk,
+    ) -> Result<(), Self::Error>;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -30,8 +30,20 @@ pub trait Step {
     /// The minimum length of a STEP pulse
     const PULSE_LENGTH: Nanoseconds;
 
+    /// The type of the DIR pin
+    type Dir;
+
+    /// The type of the STEP pin
+    type Step;
+
     /// The error that can occur while using this trait
     type Error;
+
+    /// Provides access to the DIR pin
+    fn dir_pin(&mut self) -> &mut Self::Dir;
+
+    /// Provides access to the STEP pin
+    fn step_pin(&mut self) -> &mut Self::Step;
 
     /// Rotates the motor one (micro-)step in the given direction
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 //! Contains traits that can be implemented by Step/Dir drivers
 
-use embedded_time::Clock;
+use embedded_time::{duration::Nanoseconds, Clock};
 
 use crate::{Dir, StepMode};
 
@@ -24,6 +24,12 @@ pub trait SetStepMode {
 
 /// Blocking interface for making single steps
 pub trait Step {
+    /// The time that the DIR signal must be held for a change to apply
+    const SETUP_TIME: Nanoseconds;
+
+    /// The minimum length of a STEP pulse
+    const PULSE_LENGTH: Nanoseconds;
+
     /// The error that can occur while using this trait
     type Error;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,9 @@
 //! Contains traits that can be implemented by Step/Dir drivers
 
+use embedded_hal::digital::OutputPin;
 use embedded_time::{duration::Nanoseconds, Clock};
 
-use crate::{Dir, StepMode};
+use crate::StepMode;
 
 /// Blocking interface for setting the step mode
 pub trait SetStepMode {
@@ -31,10 +32,10 @@ pub trait Step {
     const PULSE_LENGTH: Nanoseconds;
 
     /// The type of the DIR pin
-    type Dir;
+    type Dir: OutputPin<Error = Self::Error>;
 
     /// The type of the STEP pin
-    type Step;
+    type Step: OutputPin<Error = Self::Error>;
 
     /// The error that can occur while using this trait
     type Error;
@@ -44,18 +45,4 @@ pub trait Step {
 
     /// Provides access to the STEP pin
     fn step_pin(&mut self) -> &mut Self::Step;
-
-    /// Rotates the motor one (micro-)step in the given direction
-    ///
-    /// This should result in the motor making one step. To achieve a specific
-    /// speed, the user must call this method at the appropriate frequency.
-    ///
-    /// Requires a reference to an `embedded_time::Clock` implementation to
-    /// handle the timing. Please make sure that the timer doesn't overflow
-    /// while this method is running.
-    fn step<Clk: Clock>(
-        &mut self,
-        dir: Dir,
-        clock: &Clk,
-    ) -> Result<(), Self::Error>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -41,8 +41,8 @@ pub trait Step {
     type Error;
 
     /// Provides access to the DIR pin
-    fn dir_pin(&mut self) -> &mut Self::Dir;
+    fn dir(&mut self) -> &mut Self::Dir;
 
     /// Provides access to the STEP pin
-    fn step_pin(&mut self) -> &mut Self::Step;
+    fn step(&mut self) -> &mut Self::Step;
 }

--- a/templates/driver/src/lib.rs.tmpl
+++ b/templates/driver/src/lib.rs.tmpl
@@ -12,4 +12,4 @@
 #![no_std]
 #![deny(missing_docs)]
 
-pub use step_dir::\{{ name }::*, *};
+pub use step_dir::\{drivers::{ name }::*, *};

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -19,7 +19,7 @@ use step_dir::{
         timer,
     },
     embedded_time::{duration::Microseconds, Clock},
-    Dir, Step,
+    Dir, Driver, Step,
 };
 
 /// Causes probe-run to exit with exit code 0
@@ -29,14 +29,14 @@ pub fn exit() -> ! {
     }
 }
 
-pub fn test_step<Driver, Timer, A, B, DebugSignal>(
-    driver: &mut Driver,
+pub fn test_step<D, Timer, A, B, DebugSignal>(
+    driver: &mut Driver<D>,
     timer: &mut Timer,
     rotary: &mut Rotary<A, B>,
     debug_signal: &mut DebugSignal,
 ) where
-    Driver: Step,
-    Driver::Error: Debug,
+    D: Step,
+    D::Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,
     A: InputPin,
@@ -50,15 +50,15 @@ pub fn test_step<Driver, Timer, A, B, DebugSignal>(
     verify_steps(driver, timer, rotary, Dir::Backward, debug_signal);
 }
 
-pub fn verify_steps<Driver, Timer, A, B, DebugSignal>(
-    driver: &mut Driver,
+pub fn verify_steps<D, Timer, A, B, DebugSignal>(
+    driver: &mut Driver<D>,
     timer: &mut Timer,
     rotary: &mut Rotary<A, B>,
     direction: Dir,
     debug_signal: &mut DebugSignal,
 ) where
-    Driver: Step,
-    Driver::Error: Debug,
+    D: Step,
+    D::Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,
     A: InputPin,
@@ -120,8 +120,8 @@ pub fn verify_steps<Driver, Timer, A, B, DebugSignal>(
     assert_eq!(counts_expected, counts);
 }
 
-pub fn step<Driver, Timer, A, B>(
-    driver: &mut Driver,
+pub fn step<D, Timer, A, B>(
+    driver: &mut Driver<D>,
     timer: &mut Timer,
     rotary: &mut Rotary<A, B>,
     delay: Microseconds,
@@ -129,8 +129,8 @@ pub fn step<Driver, Timer, A, B>(
     check_direction: bool,
 ) -> u32
 where
-    Driver: Step,
-    Driver::Error: Debug,
+    D: Step,
+    D::Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,
     A: InputPin,

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -19,7 +19,8 @@ use step_dir::{
         timer,
     },
     embedded_time::{duration::Microseconds, Clock},
-    Dir, Driver, Step,
+    traits::Step,
+    Dir, Driver,
 };
 
 /// Causes probe-run to exit with exit code 0

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -17,7 +17,7 @@ use test_stand::{
         },
     },
     rotary_encoder_hal::Rotary,
-    step_dir::{ stspin220::STSPIN220, StepMode256},
+    step_dir::{drivers::stspin220::STSPIN220, StepMode256},
     test_step,
 };
 

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -17,18 +17,20 @@ use test_stand::{
         },
     },
     rotary_encoder_hal::Rotary,
-    step_dir::{drivers::stspin220::STSPIN220, StepMode256},
+    step_dir::{drivers::stspin220::STSPIN220, Driver, StepMode256},
     test_step,
 };
 
 struct Context {
-    driver: STSPIN220<
-        (),
-        GpioPin<PIO0_16, Output>,
-        GpioPin<PIO0_17, Output>,
-        GpioPin<PIO0_18, Output>,
-        GpioPin<PIO0_19, Output>,
-        GpioPin<PIO0_20, Output>,
+    driver: Driver<
+        STSPIN220<
+            (),
+            GpioPin<PIO0_16, Output>,
+            GpioPin<PIO0_17, Output>,
+            GpioPin<PIO0_18, Output>,
+            GpioPin<PIO0_19, Output>,
+            GpioPin<PIO0_20, Output>,
+        >,
     >,
     timer: mrt::Channel<MRT0>,
     rotary: Rotary<GpioPin<PIO0_0, Input>, GpioPin<PIO0_1, Input>>,
@@ -39,7 +41,9 @@ struct Context {
 mod tests {
     #[init]
     fn init() -> super::Context {
-        use super::{gpio, lpc8xx_hal, mrt, Rotary, StepMode256, STSPIN220};
+        use super::{
+            gpio, lpc8xx_hal, mrt, Driver, Rotary, StepMode256, STSPIN220,
+        };
 
         let p = lpc8xx_hal::Peripherals::take().unwrap();
 
@@ -88,6 +92,7 @@ mod tests {
                 &timer,
             )
             .unwrap();
+        let driver = Driver::new(driver);
 
         let rotary = Rotary::new(rotary_a, rotary_b);
 


### PR DESCRIPTION
This is a first step towards reducing the duplication between drivers, as laid out in #31. I'm already working on the next few steps, but those turned out to be a bit more involved than I had assumed. I figure it's better to get this merged piecemeal, to keep each pull request digestible.