### PR TITLE
Improve state management

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -2,7 +2,10 @@ use embedded_hal::digital::OutputPin as _;
 use embedded_time::{Clock, TimeError};
 
 use crate::{
-    traits::{Dir, SetStepMode, Step},
+    traits::{
+        Dir, EnableDirectionControl, EnableStepControl, EnableStepModeControl,
+        SetStepMode, Step,
+    },
     Direction,
 };
 
@@ -47,6 +50,32 @@ impl<T> Driver<T> {
         self.inner
     }
 
+    /// Enable microstepping mode control
+    ///
+    /// Consumes `Driver` and returns a new instance that provides control over
+    /// the microstepping mode. Once this method has been called, the
+    /// [`Driver::set_step_mode`] method becomes available.
+    ///
+    /// Takes the hardware resources that are required for controlling the
+    /// microstepping mode as an argument. What exactly those are depends on the
+    /// specific driver. Typically they are the output pins that are connected
+    /// to the mode pins of the driver.
+    ///
+    /// This method is only available, if the driver supports enabling step mode
+    /// control. It might no longer be available, once step mode control has
+    /// been enabled.
+    pub fn enable_step_mode_control<Resources>(
+        self,
+        res: Resources,
+    ) -> Driver<T::WithStepModeControl>
+    where
+        T: EnableStepModeControl<Resources>,
+    {
+        Driver {
+            inner: self.inner.enable_step_mode_control(res),
+        }
+    }
+
     /// Sets the step mode
     ///
     /// This method is only available, if the wrapped driver supports
@@ -62,6 +91,32 @@ impl<T> Driver<T> {
         T: SetStepMode,
     {
         self.inner.set_step_mode(step_mode, clock)
+    }
+
+    /// Enable direction control
+    ///
+    /// Consumes `Driver` and returns a new instance that provides control over
+    /// the motor direction. Once this method has been called, the
+    /// [`Driver::set_direction`] method becomes available.
+    ///
+    /// Takes the hardware resources that are required for controlling the
+    /// direction as an argument. What exactly those are depends on the specific
+    /// driver. Typically it's going to be the output pin that is connected to
+    /// the driver's DIR pin.
+    ///
+    /// This method is only available, if the driver supports enabling direction
+    /// control. It might no longer be available, once direction control has
+    /// been enabled.
+    pub fn enable_direction_control<Resources>(
+        self,
+        res: Resources,
+    ) -> Driver<T::WithDirectionControl>
+    where
+        T: EnableDirectionControl<Resources>,
+    {
+        Driver {
+            inner: self.inner.enable_direction_control(res),
+        }
     }
 
     /// Set direction for future movements
@@ -93,6 +148,32 @@ impl<T> Driver<T> {
         clock.new_timer(T::SETUP_TIME).start()?.wait()?;
 
         Ok(())
+    }
+
+    /// Enable step control
+    ///
+    /// Consumes `Driver` and returns a new instance that provides control over
+    /// stepping the motor. Once this method has been called, the
+    /// [`Driver::step`] method becomes available.
+    ///
+    /// Takes the hardware resources that are required for controlling the
+    /// direction as an argument. What exactly those are depends on the specific
+    /// driver. Typically it's going to be the output pin that is connected to
+    /// the driver's STEP pin.
+    ///
+    /// This method is only available, if the driver supports enabling step
+    /// control. It might no longer be available, once step control has been
+    /// enabled.
+    pub fn enable_step_control<Resources>(
+        self,
+        res: Resources,
+    ) -> Driver<T::WithStepControl>
+    where
+        T: EnableStepControl<Resources>,
+    {
+        Driver {
+            inner: self.inner.enable_step_control(res),
+        }
     }
 
     /// Rotates the motor one (micro-)step in the given direction

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -96,13 +96,14 @@ impl<T> Driver<T> {
     ///
     /// You might need to call [`Driver::enable_step_mode_control`] to make this
     /// method available.
-    pub fn set_step_mode<Clk: Clock>(
+    pub fn set_step_mode<Clk>(
         &mut self,
         step_mode: T::StepMode,
         clock: &Clk,
     ) -> Result<(), T::Error>
     where
         T: SetStepMode,
+        Clk: Clock,
     {
         self.inner.set_step_mode(step_mode, clock)
     }
@@ -154,13 +155,14 @@ impl<T> Driver<T> {
     ///
     /// You might need to call [`Driver::enable_direction_control`] to make this
     /// method available.
-    pub fn set_direction<Clk: Clock>(
+    pub fn set_direction<Clk>(
         &mut self,
         direction: Direction,
         clock: &Clk,
     ) -> Result<(), StepError<T::Error>>
     where
         T: Dir,
+        Clk: Clock,
     {
         match direction {
             Direction::Forward => self
@@ -218,12 +220,10 @@ impl<T> Driver<T> {
     ///
     /// You might need to call [`Driver::enable_step_control`] to make this
     /// method available.
-    pub fn step<Clk: Clock>(
-        &mut self,
-        clock: &Clk,
-    ) -> Result<(), StepError<T::Error>>
+    pub fn step<Clk>(&mut self, clock: &Clk) -> Result<(), StepError<T::Error>>
     where
         T: Step,
+        Clk: Clock,
     {
         // Start step pulse
         self.inner

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -76,12 +76,15 @@ impl<T> Driver<T> {
         }
     }
 
-    /// Sets the step mode
+    /// Sets the microstepping mode
     ///
     /// This method is only available, if the wrapped driver supports
     /// microstepping, and supports setting the step mode through software. Some
     /// driver might not support microstepping at all, or only allow setting the
     /// step mode by changing physical switches.
+    ///
+    /// You might need to call [`Driver::enable_step_mode_control`] to make this
+    /// method available.
     pub fn set_step_mode<Clk: Clock>(
         &mut self,
         step_mode: T::StepMode,
@@ -124,6 +127,9 @@ impl<T> Driver<T> {
     /// Requires a reference to an `embedded_time::Clock` implementation to
     /// handle the timing. Please make sure that the timer doesn't overflow
     /// while this method is running.
+    ///
+    /// You might need to call [`Driver::enable_direction_control`] to make this
+    /// method available.
     pub fn set_direction<Clk: Clock>(
         &mut self,
         direction: Direction,
@@ -185,6 +191,9 @@ impl<T> Driver<T> {
     /// Requires a reference to an `embedded_time::Clock` implementation to
     /// handle the timing. Please make sure that the timer doesn't overflow
     /// while this method is running.
+    ///
+    /// You might need to call [`Driver::enable_step_control`] to make this
+    /// method available.
     pub fn step<Clk: Clock>(
         &mut self,
         clock: &Clk,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -3,7 +3,7 @@ use embedded_time::{Clock, TimeError};
 
 use crate::{
     traits::{
-        Dir, EnableDirectionControl, EnableStepControl, EnableStepModeControl,
+        SetDirection, EnableDirectionControl, EnableStepControl, EnableStepModeControl,
         SetStepMode, Step,
     },
     Direction,
@@ -133,7 +133,7 @@ impl<T> Driver<T> {
         clock: &Clk,
     ) -> Result<
         Driver<T::WithDirectionControl>,
-        StepError<<T::WithDirectionControl as Dir>::Error>,
+        StepError<<T::WithDirectionControl as SetDirection>::Error>,
     >
     where
         T: EnableDirectionControl<Resources>,
@@ -161,7 +161,7 @@ impl<T> Driver<T> {
         clock: &Clk,
     ) -> Result<(), StepError<T::Error>>
     where
-        T: Dir,
+        T: SetDirection,
         Clk: Clock,
     {
         match direction {

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -193,8 +193,18 @@ where
         // Reset the device's internal logic and disable the h-bridge drivers.
         self.reset.try_set_low()?;
 
+        use PinState::*;
+        use StepMode32::*;
+        let (mode0, mode1, mode2) = match step_mode {
+            Full => (Low, Low, Low),
+            M2 => (High, Low, Low),
+            M4 => (Low, High, Low),
+            M8 => (High, High, Low),
+            M16 => (Low, Low, High),
+            M32 => (High, High, High),
+        };
+
         // Set mode signals.
-        let (mode0, mode1, mode2) = step_mode_to_signals(&step_mode);
         self.mode0.try_set_state(mode0)?;
         self.mode1.try_set_state(mode1)?;
         self.mode2.try_set_state(mode2)?;
@@ -238,22 +248,5 @@ where
 
     fn step(&mut self) -> &mut Self::Step {
         &mut self.step
-    }
-}
-
-/// Provides the pin signals for the given step mode
-fn step_mode_to_signals(
-    step_mode: &StepMode32,
-) -> (PinState, PinState, PinState) {
-    use PinState::*;
-    use StepMode32::*;
-
-    match step_mode {
-        Full => (Low, Low, Low),
-        M2 => (High, Low, Low),
-        M4 => (Low, High, Low),
-        M8 => (High, High, Low),
-        M16 => (Low, Low, High),
-        M32 => (High, High, High),
     }
 }

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -83,7 +83,7 @@ use embedded_time::{duration::Nanoseconds, Clock};
 
 use crate::{
     traits::{
-        Dir as DirTrait, EnableStepModeControl, SetStepMode, Step as StepTrait,
+        EnableStepModeControl, SetDirection, SetStepMode, Step as StepTrait,
     },
     ModeError, StepMode32,
 };
@@ -227,7 +227,7 @@ where
     }
 }
 
-impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> DirTrait
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> SetDirection
     for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
 where
     Dir: OutputPin<Error = OutputPinError>,

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -83,7 +83,8 @@ use embedded_time::duration::Nanoseconds;
 
 use crate::{
     traits::{
-        EnableStepModeControl, SetDirection, SetStepMode, Step as StepTrait,
+        EnableDirectionControl, EnableStepControl, EnableStepModeControl,
+        SetDirection, SetStepMode, Step as StepTrait,
     },
     StepMode32,
 };
@@ -217,6 +218,30 @@ where
     }
 }
 
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError>
+    EnableDirectionControl<Dir>
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, ()>
+where
+    Dir: OutputPin<Error = OutputPinError>,
+{
+    type WithDirectionControl =
+        DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>;
+
+    fn enable_direction_control(self, dir: Dir) -> Self::WithDirectionControl {
+        DRV8825 {
+            enable: self.enable,
+            fault: self.fault,
+            sleep: self.sleep,
+            reset: self.reset,
+            mode0: self.mode0,
+            mode1: self.mode1,
+            mode2: self.mode2,
+            step: self.step,
+            dir,
+        }
+    }
+}
+
 impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError> SetDirection
     for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>
 where
@@ -231,6 +256,30 @@ where
 
     fn dir(&mut self) -> &mut Self::Dir {
         &mut self.dir
+    }
+}
+
+impl<Reset, Mode0, Mode1, Mode2, Step, Dir, OutputPinError>
+    EnableStepControl<Step>
+    for DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, (), Dir>
+where
+    Step: OutputPin<Error = OutputPinError>,
+{
+    type WithStepControl =
+        DRV8825<(), (), (), Reset, Mode0, Mode1, Mode2, Step, Dir>;
+
+    fn enable_step_control(self, step: Step) -> Self::WithStepControl {
+        DRV8825 {
+            enable: self.enable,
+            fault: self.fault,
+            sleep: self.sleep,
+            reset: self.reset,
+            mode0: self.mode0,
+            mode1: self.mode1,
+            mode2: self.mode2,
+            step,
+            dir: self.dir,
+        }
     }
 }
 

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -59,12 +59,11 @@
 //! // need an implementation of `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP and DIR pins.
-//! let mut driver = Driver::new(
-//!     DRV8825::from_step_dir_pins(step, dir)
-//! );
+//! let mut driver = Driver::new(DRV8825::new())
+//!     .enable_direction_control(dir, Direction::Forward, &clock)?
+//!     .enable_step_control(step);
 //!
 //! // Rotate stepper motor by a few steps.
-//! driver.set_direction(Direction::Forward, &clock)?;
 //! for _ in 0 .. 5 {
 //!     let timer = clock.new_timer(STEP_DELAY).start()?;
 //!     driver.step(&clock)?;
@@ -91,9 +90,8 @@ use crate::{
 
 /// The DRV8825 driver API
 ///
-/// You can create an instance of this struct by calling
-/// [`DRV8825::from_step_dir_pins`]. See [module documentation] for a full
-/// example that uses this API.
+/// You can create an instance of this struct by calling [`DRV8825::new`]. See
+/// [module documentation] for a full example that uses this API.
 ///
 /// [module documentation]: index.html
 pub struct DRV8825<Enable, Fault, Sleep, Reset, Mode0, Mode1, Mode2, Step, Dir>
@@ -109,24 +107,13 @@ pub struct DRV8825<Enable, Fault, Sleep, Reset, Mode0, Mode1, Mode2, Step, Dir>
     dir: Dir,
 }
 
-impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
+impl DRV8825<(), (), (), (), (), (), (), (), ()> {
     /// Create a new instance of `DRV8825`
     ///
-    /// Creates an instance of this struct from just the STEP and DIR pins. It
-    /// expects the types that represent those pins to implement [`OutputPin`].
-    ///
-    /// The resulting instance can be used to step the motor using
-    /// [`DRV8825::step`]. All other capabilities of the DRV8825, like
-    /// the power-up sequence, selecting a step mode, or controlling the power
-    /// state, explicitly enabled, or managed externally.
-    ///
-    /// To enable additional capabilities, see
-    /// [`DRV8825::enable_mode_control`].
-    pub fn from_step_dir_pins<Error>(step: Step, dir: Dir) -> Self
-    where
-        Step: OutputPin<Error = Error>,
-        Dir: OutputPin<Error = Error>,
-    {
+    /// The resulting instance won't be able to do anything yet. You can call
+    /// the various `enable_` methods of [`Driver`](crate::Driver) to rectify
+    /// that.
+    pub fn new() -> Self {
         Self {
             enable: (),
             fault: (),
@@ -135,8 +122,8 @@ impl<Step, Dir> DRV8825<(), (), (), (), (), (), (), Step, Dir> {
             mode0: (),
             mode1: (),
             mode2: (),
-            step,
-            dir,
+            step: (),
+            dir: (),
         }
     }
 }

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -83,7 +83,10 @@ use embedded_hal::digital::{OutputPin, PinState};
 use embedded_time::duration::Nanoseconds;
 
 use crate::{
-    traits::{EnableStepModeControl, SetDirection, SetStepMode, Step},
+    traits::{
+        EnableDirectionControl, EnableStepControl, EnableStepModeControl,
+        SetDirection, SetStepMode, Step,
+    },
     StepMode256,
 };
 
@@ -245,6 +248,37 @@ impl<
         StepMode3,
         DirMode4,
         OutputPinError,
+    > EnableDirectionControl<DirMode4>
+    for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, ()>
+where
+    DirMode4: OutputPin<Error = OutputPinError>,
+{
+    type WithDirectionControl =
+        STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>;
+
+    fn enable_direction_control(
+        self,
+        dir_mode4: DirMode4,
+    ) -> Self::WithDirectionControl {
+        STSPIN220 {
+            enable_fault: self.enable_fault,
+            standby_reset: self.standby_reset,
+            mode1: self.mode1,
+            mode2: self.mode2,
+            step_mode3: self.step_mode3,
+            dir_mode4,
+        }
+    }
+}
+
+impl<
+        EnableFault,
+        StandbyReset,
+        Mode1,
+        Mode2,
+        StepMode3,
+        DirMode4,
+        OutputPinError,
     > SetDirection
     for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>
 where
@@ -257,6 +291,37 @@ where
 
     fn dir(&mut self) -> &mut Self::Dir {
         &mut self.dir_mode4
+    }
+}
+
+impl<
+        EnableFault,
+        StandbyReset,
+        Mode1,
+        Mode2,
+        StepMode3,
+        DirMode4,
+        OutputPinError,
+    > EnableStepControl<StepMode3>
+    for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, (), DirMode4>
+where
+    StepMode3: OutputPin<Error = OutputPinError>,
+{
+    type WithStepControl =
+        STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>;
+
+    fn enable_step_control(
+        self,
+        step_mode3: StepMode3,
+    ) -> Self::WithStepControl {
+        STSPIN220 {
+            enable_fault: self.enable_fault,
+            standby_reset: self.standby_reset,
+            mode1: self.mode1,
+            mode2: self.mode2,
+            step_mode3,
+            dir_mode4: self.dir_mode4,
+        }
     }
 }
 

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -86,7 +86,7 @@ use embedded_time::{
 };
 
 use crate::{
-    traits::{Dir, EnableStepModeControl, SetStepMode, Step},
+    traits::{SetDirection, EnableStepModeControl, SetStepMode, Step},
     ModeError, StepMode256,
 };
 
@@ -258,7 +258,7 @@ impl<
         StepMode3,
         DirMode4,
         OutputPinError,
-    > Dir
+    > SetDirection
     for STSPIN220<EnableFault, StandbyReset, Mode1, Mode2, StepMode3, DirMode4>
 where
     DirMode4: OutputPin<Error = OutputPinError>,

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -208,8 +208,21 @@ where
         // Force driver into standby mode.
         self.standby_reset.try_set_low()?;
 
+        use PinState::*;
+        use StepMode256::*;
+        let (mode1, mode2, mode3, mode4) = match step_mode {
+            Full => (Low, Low, Low, Low),
+            M2 => (High, Low, High, Low),
+            M4 => (Low, High, Low, High),
+            M8 => (High, High, High, Low),
+            M16 => (High, High, High, High),
+            M32 => (Low, High, Low, Low),
+            M64 => (High, High, Low, High),
+            M128 => (High, Low, Low, Low),
+            M256 => (High, High, Low, Low),
+        };
+
         // Set mode signals.
-        let (mode1, mode2, mode3, mode4) = step_mode_to_signals(&step_mode);
         self.mode1.try_set_state(mode1)?;
         self.mode2.try_set_state(mode2)?;
         self.step_mode3.try_set_state(mode3)?;
@@ -267,24 +280,5 @@ where
 
     fn step(&mut self) -> &mut Self::Step {
         &mut self.step_mode3
-    }
-}
-
-/// Provides the pin signals for the given step mode
-pub fn step_mode_to_signals(
-    step_mode: &StepMode256,
-) -> (PinState, PinState, PinState, PinState) {
-    use PinState::*;
-    use StepMode256::*;
-    match step_mode {
-        Full => (Low, Low, Low, Low),
-        M2 => (High, Low, High, Low),
-        M4 => (Low, High, Low, High),
-        M8 => (High, High, High, Low),
-        M16 => (High, High, High, High),
-        M32 => (Low, High, Low, Low),
-        M64 => (High, High, Low, High),
-        M128 => (High, Low, Low, Low),
-        M256 => (High, High, Low, Low),
     }
 }

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -60,12 +60,11 @@
 //! // `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP/MODE3 and DIR/MODE4 pins.
-//! let mut driver = Driver::new(
-//!     STSPIN220::from_step_dir_pins(step_mode3, dir_mode4)
-//! );
+//! let mut driver = Driver::new(STSPIN220::new())
+//!     .enable_direction_control(dir_mode4, Direction::Forward, &clock)?
+//!     .enable_step_control(step_mode3);
 //!
 //! // Rotate stepper motor by a few steps.
-//! driver.set_direction(Direction::Forward, &clock)?;
 //! for _ in 0 .. 5 {
 //!     let timer = clock.new_timer(STEP_DELAY).start()?;
 //!     driver.step(&clock)?;
@@ -92,9 +91,8 @@ use crate::{
 
 /// The STSPIN220 driver API
 ///
-/// You can create an instance of this struct by calling
-/// [`STSPIN220::from_step_dir_pins`]. See [module documentation] for a full
-/// example that uses this API.
+/// You can create an instance of this struct by calling [`STSPIN220::new`]. See
+/// [module documentation] for a full example that uses this API.
 ///
 /// [module documentation]: index.html
 pub struct STSPIN220<
@@ -113,35 +111,20 @@ pub struct STSPIN220<
     dir_mode4: DirMode4,
 }
 
-impl<StepMode3, DirMode4> STSPIN220<(), (), (), (), StepMode3, DirMode4> {
+impl STSPIN220<(), (), (), (), (), ()> {
     /// Create a new instance of `STSPIN220`
     ///
-    /// Creates an instance of this struct from just the STEP/MODE3 and
-    /// DIR/MODE4 pins. It expects the types that represent those pins to
-    /// implement [`OutputPin`].
-    ///
-    /// The resulting instance can be used to step the motor using
-    /// [`STSPIN220::step`]. All other capabilities of the STSPIN220, like
-    /// the power-up sequence, selecting a step mode, or controlling the power
-    /// state, explicitly enabled, or managed externally.
-    ///
-    /// To enable additional capabilities, see
-    /// [`STSPIN220::enable_mode_control`].
-    pub fn from_step_dir_pins<Error>(
-        step_mode3: StepMode3,
-        dir_mode4: DirMode4,
-    ) -> Self
-    where
-        StepMode3: OutputPin<Error = Error>,
-        DirMode4: OutputPin<Error = Error>,
-    {
+    /// The resulting instance won't be able to do anything yet. You can call
+    /// the various `enable_` methods of [`Driver`](crate::Driver) to rectify
+    /// that.
+    pub fn new() -> Self {
         Self {
             enable_fault: (),
             standby_reset: (),
             mode1: (),
             mode2: (),
-            step_mode3,
-            dir_mode4,
+            step_mode3: (),
+            dir_mode4: (),
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,6 +5,21 @@ use embedded_time::{duration::Nanoseconds, Clock};
 
 use crate::StepMode;
 
+/// Enable microstepping mode control for a driver
+///
+/// The `Resources` type parameter defines the hardware resources required for
+/// controlling microstepping mode.
+pub trait EnableStepModeControl<Resources> {
+    /// The type of the driver once microstepping mode control has been enabled
+    type WithStepModeControl: SetStepMode;
+
+    /// Enable microstepping mode control
+    fn enable_step_mode_control(
+        self,
+        res: Resources,
+    ) -> Self::WithStepModeControl;
+}
+
 /// Implemented by drivers that support controlling the microstepping mode
 pub trait SetStepMode {
     /// The error that can occur while using this trait
@@ -23,6 +38,21 @@ pub trait SetStepMode {
     ) -> Result<(), Self::Error>;
 }
 
+/// Enable direction control for a driver
+///
+/// The `Resources` type parameter defines the hardware resources required for
+/// direction control.
+pub trait EnableDirectionControl<Resources> {
+    /// The type of the driver once direction control has been enabled
+    type WithDirectionControl: Dir;
+
+    /// Enable direction control
+    fn enable_direction_control(
+        self,
+        res: Resources,
+    ) -> Self::WithDirectionControl;
+}
+
 /// Implemented by drivers that support controlling the DIR signal
 pub trait Dir {
     /// The time that the DIR signal must be held for a change to apply
@@ -36,6 +66,18 @@ pub trait Dir {
 
     /// Provides access to the DIR pin
     fn dir(&mut self) -> &mut Self::Dir;
+}
+
+/// Enable step control for a driver
+///
+/// The `Resources` type parameter defines the hardware resources required for
+/// step control.
+pub trait EnableStepControl<Resources> {
+    /// The type of the driver once direction control has been enabled
+    type WithStepControl: Step;
+
+    /// Enable step control
+    fn enable_step_control(self, res: Resources) -> Self::WithStepControl;
 }
 
 /// Implemented by drivers that support controlling the STEP signal

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 //! Contains traits that can be implemented by Step/Dir drivers
 
 use embedded_hal::digital::OutputPin;
-use embedded_time::{duration::Nanoseconds, Clock};
+use embedded_time::duration::Nanoseconds;
 
 use crate::StepMode;
 
@@ -36,12 +36,17 @@ pub trait SetStepMode {
     /// This crate includes a number of enums that can be used for this purpose.
     type StepMode: StepMode;
 
-    /// Sets the step mode
-    fn set_step_mode<Clk: Clock>(
+    /// Apply the new step mode configuration
+    ///
+    /// Typically this puts the driver into reset and sets the mode pins
+    /// according to the new step mode.
+    fn apply_mode_config(
         &mut self,
         step_mode: Self::StepMode,
-        clock: &Clk,
     ) -> Result<(), Self::Error>;
+
+    /// Re-enable the driver after the mode has been set
+    fn enable_driver(&mut self) -> Result<(), Self::Error>;
 }
 
 /// Enable direction control for a driver

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -44,7 +44,7 @@ pub trait SetStepMode {
 /// direction control.
 pub trait EnableDirectionControl<Resources> {
     /// The type of the driver once direction control has been enabled
-    type WithDirectionControl: Dir;
+    type WithDirectionControl: SetDirection;
 
     /// Enable direction control
     fn enable_direction_control(
@@ -54,7 +54,7 @@ pub trait EnableDirectionControl<Resources> {
 }
 
 /// Implemented by drivers that support controlling the DIR signal
-pub trait Dir {
+pub trait SetDirection {
     /// The time that the DIR signal must be held for a change to apply
     const SETUP_TIME: Nanoseconds;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,6 +22,12 @@ pub trait EnableStepModeControl<Resources> {
 
 /// Implemented by drivers that support controlling the microstepping mode
 pub trait SetStepMode {
+    /// The time the mode signals need to be held before re-enabling the driver
+    const SETUP_TIME: Nanoseconds;
+
+    /// The time the mode signals need to be held after re-enabling the driver
+    const HOLD_TIME: Nanoseconds;
+
     /// The error that can occur while using this trait
     type Error;
 

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -19,7 +19,7 @@ use step_dir::{
         timer,
     },
     embedded_time::{duration::Microseconds, Clock},
-    traits::{Dir, Step},
+    traits::{SetDirection, Step},
     Direction, Driver,
 };
 
@@ -36,7 +36,7 @@ pub fn test_step<D, Timer, A, B, DebugSignal, Error>(
     rotary: &mut Rotary<A, B>,
     debug_signal: &mut DebugSignal,
 ) where
-    D: Dir<Error = Error> + Step<Error = Error>,
+    D: SetDirection<Error = Error> + Step<Error = Error>,
     Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,
@@ -58,7 +58,7 @@ pub fn verify_steps<D, Timer, A, B, DebugSignal, Error>(
     direction: Direction,
     debug_signal: &mut DebugSignal,
 ) where
-    D: Dir<Error = Error> + Step<Error = Error>,
+    D: SetDirection<Error = Error> + Step<Error = Error>,
     Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,
@@ -130,7 +130,7 @@ pub fn step<D, Timer, A, B, Error>(
     check_direction: bool,
 ) -> u32
 where
-    D: Dir<Error = Error> + Step<Error = Error>,
+    D: SetDirection<Error = Error> + Step<Error = Error>,
     Error: Debug,
     Timer: timer::CountDown<Time = u32> + Clock,
     Timer::Error: Debug,

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -83,16 +83,14 @@ mod tests {
         let mut timer = mrt.mrt0;
 
         timer.start(mrt::MAX_VALUE);
-        let driver = STSPIN220::from_step_dir_pins(step_mode3, dir_mode4)
-            .enable_mode_control(
-                standby_reset,
-                mode1,
-                mode2,
+        let driver = STSPIN220::from_step_dir_pins(step_mode3, dir_mode4);
+        let driver = Driver::new(driver)
+            .enable_step_mode_control(
+                (standby_reset, mode1, mode2),
                 StepMode256::Full,
                 &timer,
             )
             .unwrap();
-        let driver = Driver::new(driver);
 
         let rotary = Rotary::new(rotary_a, rotary_b);
 

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -17,7 +17,7 @@ use test_stand::{
         },
     },
     rotary_encoder_hal::Rotary,
-    step_dir::{drivers::stspin220::STSPIN220, Driver, StepMode256},
+    step_dir::{drivers::stspin220::STSPIN220, Direction, Driver, StepMode256},
     test_step,
 };
 
@@ -42,7 +42,8 @@ mod tests {
     #[init]
     fn init() -> super::Context {
         use super::{
-            gpio, lpc8xx_hal, mrt, Driver, Rotary, StepMode256, STSPIN220,
+            gpio, lpc8xx_hal, mrt, Direction, Driver, Rotary, StepMode256,
+            STSPIN220,
         };
 
         let p = lpc8xx_hal::Peripherals::take().unwrap();
@@ -83,8 +84,10 @@ mod tests {
         let mut timer = mrt.mrt0;
 
         timer.start(mrt::MAX_VALUE);
-        let driver = STSPIN220::from_step_dir_pins(step_mode3, dir_mode4);
-        let driver = Driver::new(driver)
+        let driver = Driver::new(STSPIN220::new())
+            .enable_step_control(step_mode3)
+            .enable_direction_control(dir_mode4, Direction::Forward, &timer)
+            .unwrap()
             .enable_step_mode_control(
                 (standby_reset, mode1, mode2),
                 StepMode256::Full,


### PR DESCRIPTION
This pull request makes all driver state management available through the abstract `Driver` API, and further reduces the duplicated code between drivers (what's left is due to the drivers having similar structures and implementing the same traits).

This is not quite done. It still requires some testing, and CI will probably fail due to documentation and the test stand not being fully updated. I figured I'd still submit this as a draft, as the work week is over for me. I'll clean it up next week.

Blocked on #53.

Close #31