### PR TITLE
Switch to upstream version of rotary-encoder-hal

### DIFF
--- a/test-stand/Cargo.toml
+++ b/test-stand/Cargo.toml
@@ -19,11 +19,8 @@ panic-probe = "0.1.0"
 git      = "https://github.com/lpc-rs/lpc8xx-hal.git"
 features = ["845m301jhi48", "845-rt"]
 
-# My own fork of rotary-encoder-hal. Currently includes the following pull
-# requests:
-# - https://github.com/leshow/rotary-encoder-hal/pull/7
 [dependencies.rotary-encoder-hal]
-git      = "https://github.com/braun-embedded/rotary-encoder-hal.git"
+version  = "0.3.0"
 features = ["defmt", "embedded-hal-alpha"]
 
 [dependencies.step-dir]


### PR DESCRIPTION
All of my pull requests have been merged and a new version has been
released.