### PR TITLE
Rename `Driver` constructor; update its documentation

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -23,7 +23,7 @@ impl<T> Driver<T> {
     /// Since `Driver` only provides an abstract interface for _using_ a driver,
     /// not for initializing it, you have to initialize a concrete driver and
     /// pass it to this constructor.
-    pub fn new(inner: T) -> Self {
+    pub fn from_inner(inner: T) -> Self {
         Self { inner }
     }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -19,10 +19,6 @@ pub struct Driver<T> {
 
 impl<T> Driver<T> {
     /// Create a new `Driver` instance from a concrete driver
-    ///
-    /// Since `Driver` only provides an abstract interface for _using_ a driver,
-    /// not for initializing it, you have to initialize a concrete driver and
-    /// pass it to this constructor.
     pub fn from_inner(inner: T) -> Self {
         Self { inner }
     }

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -59,7 +59,7 @@
 //! // need an implementation of `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP and DIR pins.
-//! let mut driver = Driver::new(DRV8825::new())
+//! let mut driver = Driver::from_inner(DRV8825::new())
 //!     .enable_direction_control(dir, Direction::Forward, &clock)?
 //!     .enable_step_control(step);
 //!

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -60,7 +60,7 @@
 //! // `embedded_hal::blocking::DelayUs`.
 //!
 //! // Create driver API from STEP/MODE3 and DIR/MODE4 pins.
-//! let mut driver = Driver::new(STSPIN220::new())
+//! let mut driver = Driver::from_inner(STSPIN220::new())
 //!     .enable_direction_control(dir_mode4, Direction::Forward, &clock)?
 //!     .enable_step_control(step_mode3);
 //!

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -84,7 +84,7 @@ mod tests {
         let mut timer = mrt.mrt0;
 
         timer.start(mrt::MAX_VALUE);
-        let driver = Driver::new(STSPIN220::new())
+        let driver = Driver::from_inner(STSPIN220::new())
             .enable_step_control(step_mode3)
             .enable_direction_control(dir_mode4, Direction::Forward, &timer)
             .unwrap()


### PR DESCRIPTION
Currently blocked on #54.