### PR TITLE
Add function to `Driver` that returns pulse length

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -319,6 +319,14 @@ impl<T> Driver<T> {
 
         Ok(())
     }
+
+    /// Returns the step pulse length of the wrapped driver
+    pub fn pulse_length(&self) -> Nanoseconds
+    where
+        T: Step,
+    {
+        T::PULSE_LENGTH
+    }
 }
 
 /// An error that can occur while using this API

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -142,7 +142,10 @@ where
     driver.step(timer).unwrap();
 
     timer.start(mrt::MAX_VALUE);
-    let step_timer = timer.new_timer(delay - D::PULSE_LENGTH).start().unwrap();
+    let step_timer = timer
+        .new_timer(delay - driver.pulse_length())
+        .start()
+        .unwrap();
 
     let mut counts = 0;
 


### PR DESCRIPTION
This provides a convenient way to access the pulse length, without
having to refer to the driver by name, or through a (possibly
cumbersome) generic parameter.