### PR TITLE
Make `step_mode` public, remove re-exports

### DIFF
--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -12,11 +12,11 @@ use embedded_hal::digital::{OutputPin, PinState};
 use embedded_time::duration::Nanoseconds;
 
 use crate::{
+    step_mode::StepMode32,
     traits::{
         EnableDirectionControl, EnableStepControl, EnableStepModeControl,
         SetDirection, SetStepMode, Step as StepTrait,
     },
-    StepMode32,
 };
 
 /// The DRV8825 driver API

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -12,11 +12,11 @@ use embedded_hal::digital::{OutputPin, PinState};
 use embedded_time::duration::Nanoseconds;
 
 use crate::{
+    step_mode::StepMode256,
     traits::{
         EnableDirectionControl, EnableStepControl, EnableStepModeControl,
         SetDirection, SetStepMode, Step,
     },
-    StepMode256,
 };
 
 /// The STSPIN220 driver API

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,12 @@ pub extern crate embedded_hal;
 pub extern crate embedded_time;
 
 pub mod drivers;
+pub mod step_mode;
 pub mod traits;
 
 mod driver;
-mod step_mode;
 
-pub use self::{driver::*, step_mode::*};
+pub use self::driver::*;
 
 /// Defines the direction in which to rotate the motor
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/step_mode.rs
+++ b/src/step_mode.rs
@@ -1,3 +1,5 @@
+//! Types related to working with a driver's microstepping mode
+
 use core::convert::TryFrom;
 
 use paste::paste;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@
 use embedded_hal::digital::OutputPin;
 use embedded_time::duration::Nanoseconds;
 
-use crate::StepMode;
+use crate::step_mode::StepMode;
 
 /// Enable microstepping mode control for a driver
 ///

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -17,7 +17,10 @@ use test_stand::{
         },
     },
     rotary_encoder_hal::Rotary,
-    step_dir::{drivers::stspin220::STSPIN220, Direction, Driver, StepMode256},
+    step_dir::{
+        drivers::stspin220::STSPIN220, step_mode::StepMode256, Direction,
+        Driver,
+    },
     test_step,
 };
 


### PR DESCRIPTION
The module contains a lot of types that use up a lot of real estate in
the top-level namespace. Making the module public makes more sense, I
think. It might also make sense to selectively re-export some of its
types, but I'm not sure about that yet.